### PR TITLE
LucidMainWindow

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+[run]
+source =
+    lucid 
+[report]
+omit =
+    #tests
+    */tests/*
+    *test*
+    #versioning
+    .*version.*
+    *_version.py

--- a/lucid/__init__.py
+++ b/lucid/__init__.py
@@ -1,3 +1,6 @@
+__all__ = ['LucidMainWindow']
+
+from .main_window import LucidMainWindow
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -40,3 +40,16 @@ class LucidMainWindow(QMainWindow):
         """QDockWidget children"""
         return [widget for widget in self.children()
                 if isinstance(widget, QDockWidget)]
+
+    @classmethod
+    def find_window(cls, widget):
+        """
+        Navigate the widget hierarchy to find instance of LucidMainWindow
+        """
+        parent = widget.parent()
+        if isinstance(parent, cls):
+            return parent
+        elif parent is None:
+            raise EnvironmentError("No LucidMainWindow can be found "
+                                   "in widget hierarchy")
+        return cls.find_window(parent)

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -29,8 +29,8 @@ class LucidMainWindow(QMainWindow):
     """
     allowed_docks = (Qt.RightDockWidgetArea, )
 
-    def __init__(self, *args):
-        super().__init__(*args)
+    def __init__(self, parent=None):
+        super().__init__(parent=parent)
         # This means when multiple docks are pulled into an area, we create a
         # tab system. Splitting docks is still possible through API
         self.setDockOptions(self.AnimatedDocks | self.ForceTabbedDocks)

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -1,0 +1,42 @@
+import functools
+import operator
+
+from qtpy.QtWidgets import QMainWindow, QDockWidget, QStackedWidget
+from qtpy.QtCore import Qt
+
+
+class LucidMainWindow(QMainWindow):
+    """QMainWindow for Lucid Applications"""
+    allowed_docks = (Qt.RightDockWidgetArea, )
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        # This means when multiple docks are pulled into an area, we create a
+        # tab system. Splitting docks is still possible through API
+        self.setDockOptions(self.AnimatedDocks | self.ForceTabbedDocks)
+        self.setCentralWidget(QStackedWidget())
+        # Adjust corners
+        self.setCorner(Qt.TopRightCorner, Qt.RightDockWidgetArea)
+        self.setCorner(Qt.BottomRightCorner, Qt.RightDockWidgetArea)
+
+    def addDockWidget(self, area, dock):
+        """Wrapped QMainWindow.addDockWidget"""
+        # Force the dockwidget to only be allowed in areas determined by the
+        # LucidMainWindow.allowed_docks
+        allowed_flags = functools.reduce(operator.or_, self.allowed_docks)
+        dock.setAllowedAreas(allowed_flags)
+        super().addDockWidget(area, dock)
+        # If we already have an embedded dock, add it to existing dock. This
+        # needs to exist because even with ForceTabbedDocks the dock will be
+        # split if we add with regular API
+        embedded_docks = [curr_dock for curr_dock in self._docks
+                          if self.dockWidgetArea(curr_dock) == area
+                          and curr_dock.isVisible()]
+        if embedded_docks:
+            super().tabifyDockWidget(embedded_docks[0], dock)
+
+    @property
+    def _docks(self):
+        """QDockWidget children"""
+        return [widget for widget in self.children()
+                if isinstance(widget, QDockWidget)]

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -80,6 +80,10 @@ class LucidMainWindow(QMainWindow):
             widget = func()
             try:
                 window = cls.find_window(widget)
+            except AttributeError:
+                logger.error("Method %r was expected to return a QObject. "
+                             "Instead, %r was received.",
+                             func.__name__, widget)
             except EnvironmentError:
                 logger.error("No LucidMainWindow found! Unable to "
                              "embed %r in dock", widget)

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -11,7 +11,22 @@ logger = logging.getLogger(__name__)
 
 
 class LucidMainWindow(QMainWindow):
-    """QMainWindow for Lucid Applications"""
+    """
+    QMainWindow for LUCID Applications
+
+    The skeleton of the LUCID application, the window consists of a static
+    toolbar, a variety of central views for devices and scripts required for
+    operation, and also the docking system for launching detailed windows.
+
+    Attributes
+    ----------
+    allowed_docks: tuple
+        ``Qt.DockWidgetAreas`` that accept QWidgets
+
+    Parameters
+    ----------
+    parent: optional
+    """
     allowed_docks = (Qt.RightDockWidgetArea, )
 
     def __init__(self, *args):
@@ -27,7 +42,22 @@ class LucidMainWindow(QMainWindow):
         self.addToolBar(Qt.TopToolBarArea, LucidToolBar())
 
     def addDockWidget(self, area, dock):
-        """Wrapped QMainWindow.addDockWidget"""
+        """
+        Wrapped QMainWindow.addDockWidget
+
+        Add a QDockWidget to the LucidMainWindow. This is necessary in order to
+        force the tabbed behavior desired in the window. In addition it
+        performs the basic setup so the QDockWidget can be dragged to the
+        proper areas of the window, and also sets the focus on the dock so it
+        is immediately visible. This should rarely be called by external
+        users instead use the :meth:`.in_dock` decorator.
+
+        Parameters
+        ----------
+        area: Qt.DockWidgetArea
+
+        dock: QDockWidget
+        """
         # Force the dockwidget to only be allowed in areas determined by the
         # LucidMainWindow.allowed_docks
         allowed_flags = functools.reduce(operator.or_, self.allowed_docks)
@@ -56,6 +86,14 @@ class LucidMainWindow(QMainWindow):
     def find_window(cls, widget):
         """
         Navigate the widget hierarchy to find instance of LucidMainWindow
+
+        Parameters
+        ----------
+        widget: QWidget
+
+        Returns
+        -------
+        window: LucidMainWindow
         """
         parent = widget.parent()
         if isinstance(parent, cls):
@@ -67,7 +105,25 @@ class LucidMainWindow(QMainWindow):
 
     @classmethod
     def in_dock(cls, func=None, area=None):
-        """Wrapper to show QWidget in LucidMainWindow"""
+        """
+        Wrapper to show QWidget in ``LucidMainWindow``
+
+        This allows any widget that is contained within the ``LucidMainWindow``
+        the ability to display a widget in the docking system without needing
+        to have direct access to the ``LucidMainWindow`` itself.
+
+        The widget returned **must** share a parent hierarchy with a
+        ``LucidMainWindow``. See :meth:`.find_window` for more detail.
+
+        Example
+        -------
+        .. code:: python
+
+            @LucidMainWindow.in_dock
+            def dock_my_button(parent):
+                button = QPushButton(parent=parent)
+                return button
+        """
         # Use first allowed area if None supplied
         area = area or cls.allowed_docks[0]
         # When the decorator is not called

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -37,6 +37,10 @@ class LucidMainWindow(QMainWindow):
                           and curr_dock.isVisible()]
         if embedded_docks:
             super().tabifyDockWidget(embedded_docks[0], dock)
+        # Raise to visible
+        dock.show()
+        dock.raise_()
+        dock.setFocus()
 
     @property
     def _docks(self):

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -2,7 +2,9 @@ import functools
 import logging
 import operator
 
-from qtpy.QtWidgets import QMainWindow, QDockWidget, QStackedWidget
+from qtpy.QtWidgets import (QMainWindow, QDockWidget, QStackedWidget,
+                            QToolBar, QStyle, QLineEdit, QSizePolicy,
+                            QWidget)
 from qtpy.QtCore import Qt
 
 logger = logging.getLogger(__name__)
@@ -21,6 +23,8 @@ class LucidMainWindow(QMainWindow):
         # Adjust corners
         self.setCorner(Qt.TopRightCorner, Qt.RightDockWidgetArea)
         self.setCorner(Qt.BottomRightCorner, Qt.RightDockWidgetArea)
+        # Add toolbar
+        self.addToolBar(Qt.TopToolBarArea, LucidToolBar())
 
     def addDockWidget(self, area, dock):
         """Wrapped QMainWindow.addDockWidget"""
@@ -92,3 +96,27 @@ class LucidMainWindow(QMainWindow):
             return widget
 
         return wrapper
+
+
+class LucidToolBar(QToolBar):
+    """LucidToolBar for LucidMainWindow"""
+    def __init__(self, parent=None):
+        super().__init__(parent=parent)
+        # Toolbar Configuration
+        self.setMovable(False)
+        self.setLayoutDirection(Qt.LeftToRight)
+        # Back and Forward
+        self.addAction(self.style().standardIcon(QStyle.SP_ArrowLeft),
+                       'Back')
+        self.addAction(self.style().standardIcon(QStyle.SP_ArrowRight),
+                       'Forward')
+        self.addSeparator()
+        # Spacer
+        spacer = QWidget()
+        spacer.setSizePolicy(QSizePolicy.MinimumExpanding,
+                             QSizePolicy.MinimumExpanding)
+        self.addWidget(spacer)
+        # Search
+        edit = QLineEdit()
+        edit.setPlaceholderText("Search ...")
+        self.addWidget(edit)

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -36,3 +36,23 @@ def test_main_window_find_window_with_orphan(qtbot):
     qtbot.addWidget(widget)
     with pytest.raises(EnvironmentError):
         LucidMainWindow.find_window(widget)
+
+
+def test_main_window_in_dock(main_window):
+
+    @LucidMainWindow.in_dock
+    def create_widget():
+        return QWidget(parent=main_window)
+
+    create_widget()
+    assert len(main_window._docks) == 1
+
+
+def test_main_window_in_dock_with_area(main_window):
+
+    @LucidMainWindow.in_dock(area=Qt.RightDockWidgetArea)
+    def create_widget():
+        return QWidget(parent=main_window)
+
+    create_widget()
+    assert len(main_window._docks) == 1

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -12,9 +12,11 @@ def main_window(qtbot):
     return main_window
 
 
-def test_add_multiple_docks(main_window):
+def test_add_multiple_docks(main_window, qtbot):
     first_dock = QDockWidget()
     second_dock = QDockWidget()
+    for dock in (first_dock, second_dock):
+        qtbot.addWidget(dock)
     main_window.addDockWidget(Qt.RightDockWidgetArea, first_dock)
     assert main_window.dockWidgetArea(first_dock) == Qt.RightDockWidgetArea
     assert first_dock in main_window._docks
@@ -23,9 +25,11 @@ def test_add_multiple_docks(main_window):
     assert main_window.dockWidgetArea(second_dock) == Qt.RightDockWidgetArea
 
 
-def test_main_window_find_window(main_window):
+def test_main_window_find_window(main_window, qtbot):
     widget = QWidget()
+    qtbot.addWidget(widget)
     dock = QDockWidget()
+    qtbot.addWidget(dock)
     dock.setWidget(widget)
     main_window.addDockWidget(Qt.RightDockWidgetArea, dock)
     assert LucidMainWindow.find_window(widget) == main_window
@@ -38,21 +42,25 @@ def test_main_window_find_window_with_orphan(qtbot):
         LucidMainWindow.find_window(widget)
 
 
-def test_main_window_in_dock(main_window):
+def test_main_window_in_dock(main_window, qtbot):
 
     @LucidMainWindow.in_dock
     def create_widget():
-        return QWidget(parent=main_window)
+        widget = QWidget(parent=main_window)
+        qtbot.addWidget(widget)
+        return widget
 
     create_widget()
     assert len(main_window._docks) == 1
 
 
-def test_main_window_in_dock_with_area(main_window):
+def test_main_window_in_dock_with_area(main_window, qtbot):
 
     @LucidMainWindow.in_dock(area=Qt.RightDockWidgetArea)
     def create_widget():
-        return QWidget(parent=main_window)
+        widget = QWidget(parent=main_window)
+        qtbot.addWidget(widget)
+        return widget
 
     create_widget()
     assert len(main_window._docks) == 1

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -1,0 +1,38 @@
+import pytest
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QDockWidget, QWidget
+
+from lucid import LucidMainWindow
+
+
+@pytest.fixture(scope='function')
+def main_window(qtbot):
+    main_window = LucidMainWindow()
+    qtbot.addWidget(main_window)
+    return main_window
+
+
+def test_add_multiple_docks(main_window):
+    first_dock = QDockWidget()
+    second_dock = QDockWidget()
+    main_window.addDockWidget(Qt.RightDockWidgetArea, first_dock)
+    assert main_window.dockWidgetArea(first_dock) == Qt.RightDockWidgetArea
+    assert first_dock in main_window._docks
+    main_window.addDockWidget(Qt.RightDockWidgetArea, second_dock)
+    assert main_window.dockWidgetArea(first_dock) == Qt.RightDockWidgetArea
+    assert main_window.dockWidgetArea(second_dock) == Qt.RightDockWidgetArea
+
+
+def test_main_window_find_window(main_window):
+    widget = QWidget()
+    dock = QDockWidget()
+    dock.setWidget(widget)
+    main_window.addDockWidget(Qt.RightDockWidgetArea, dock)
+    assert LucidMainWindow.find_window(widget) == main_window
+
+
+def test_main_window_find_window_with_orphan(qtbot):
+    widget = QWidget()
+    qtbot.addWidget(widget)
+    with pytest.raises(EnvironmentError):
+        LucidMainWindow.find_window(widget)

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -56,3 +56,15 @@ def test_main_window_in_dock_with_area(main_window):
 
     create_widget()
     assert len(main_window._docks) == 1
+
+
+def test_main_window_in_dock_with_orphan(qtbot):
+
+    @LucidMainWindow.in_dock
+    def create_widget():
+        widget = QWidget()
+        qtbot.addWidget(widget)
+        return widget
+
+    widget = create_widget()
+    assert widget.isVisible()


### PR DESCRIPTION
PR #1 !!! 🎉 

# Description
This is the first draft of the window management system for the L2S-I home screens. The idea is there is a central view (or multiple views), these will have buttons that launch detailed screens in the right half of the window. By using the `QDockWidget` setup I can drag these docks around, re-attach them e.t.c

The other thing I was pondering for a while was how a child of a child of a child of widget was going to make sure they could expand something in the dock system. What I came up with (with help from @ZLLentz) is that you could traverse backwards up your parent tree and find the closest`LucidMainWindow`. This means that we could live in a world in which we have multiple main windows open and everything still works. The classmethods `LucidMainWindow.find_window` and `LucidMainWindow.in_dock` help you out here and let your child widget have something like:

```python
@LucidMainWindow.in_dock
def show_detailed(self):
    widget = self.generate_detailed_screen()
    widget.setParent(self)  # This is crucial
    return widget
```
The one caveat is if you forget to "parent" your widget that you return we can't navigate back to the `LucidMainWindow`. I put an escape hatch for this case and the widget will be shown as a QDialog.

Also if you see some strange things with the docking setup it is because the `ForceTabbedDocks` option on the `QMainWindow` is inherently broken, hence the `addDockWidget` shenanigans.

![main_window](https://user-images.githubusercontent.com/25753048/55606322-35d7f100-572d-11e9-80a6-39b362147270.gif)

