### PR TITLE
FIX & ENH: Docking fix work

### DIFF
--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -137,6 +137,9 @@ class LucidMainWindow(QMainWindow):
 
             dock = window.dock_manager.findDockWidget(title)
             if dock:
+                active_slot(True)
+                window.dock_manager.addDockWidgetTab(
+                    QtAds.RightDockWidgetArea, dock)
                 dock.toggleView(True)
                 return widget
 

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -137,7 +137,7 @@ class LucidMainWindow(QMainWindow):
 
             dock = window.dock_manager.findDockWidget(title)
             if dock:
-                window.dock_manager.dockArea(0).setCurrentDockWidget(dock)
+                dock.toggleView(True)
                 return widget
 
             dock = QtAds.CDockWidget(title)

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -144,7 +144,8 @@ class LucidMainWindow(QMainWindow):
                 widget.raise_()
 
                 if active_slot:
-                    # TODO: active_slot(False) is not called
+                    # Connect dock closed callback to active_slot False
+                    dock.closed.connect(functools.partial(active_slot, False))
                     active_slot(True)
 
             return widget

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -129,7 +129,7 @@ class LucidMainWindow(QMainWindow):
             # Retrieve widget
             widget = func()
             window = LucidMainWindow()
-            title = kwargs.get('title', None)
+
             # Add the widget to the dock
             if not title:
                 title = widget.objectName()
@@ -148,6 +148,7 @@ class LucidMainWindow(QMainWindow):
 
             # Ensure the main dock is actually visible
             widget.raise_()
+            widget.setVisible(True)
 
             if active_slot:
                 # Connect dock closed callback to active_slot False

--- a/lucid/overview.py
+++ b/lucid/overview.py
@@ -19,10 +19,10 @@ class BaseDeviceButton(QPushButton):
         self._device_displays = {}
         self._suite = None
         # Click button action
-        self.clicked.connect(LucidMainWindow.in_dock(
+        self.clicked.connect(partial(LucidMainWindow.in_dock(
                                         self.show_all,
                                         title=self.title,
-                                        active_slot=self._devices_shown))
+                                        active_slot=self._devices_shown), title=self.title))
         # Setup Menu
         self.setContextMenuPolicy(Qt.DefaultContextMenu)
         self.device_menu = QMenu()

--- a/lucid/overview.py
+++ b/lucid/overview.py
@@ -4,14 +4,16 @@ from functools import partial
 from qtpy.QtCore import QEvent, Qt, Property, QSize
 from qtpy.QtGui import QContextMenuEvent, QHoverEvent
 from qtpy.QtWidgets import (QPushButton, QMenu, QGridLayout, QWidget)
+from typhon.utils import reload_widget_stylesheet
+
 from lucid import LucidMainWindow
 from lucid.utils import (SnakeLayout, indicator_for_device, display_for_device,
                          suite_for_devices)
-from typhon.utils import reload_widget_stylesheet
 
 
 class BaseDeviceButton(QPushButton):
     """Base class for QPushButton to show devices"""
+
     def __init__(self, title, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.title = title
@@ -19,10 +21,10 @@ class BaseDeviceButton(QPushButton):
         self._device_displays = {}
         self._suite = None
         # Click button action
-        self.clicked.connect(partial(LucidMainWindow.in_dock(
-                                        self.show_all,
-                                        title=self.title,
-                                        active_slot=self._devices_shown), title=self.title))
+        self.clicked.connect(LucidMainWindow.in_dock(
+            self.show_all,
+            title=self.title,
+            active_slot=self._devices_shown))
         # Setup Menu
         self.setContextMenuPolicy(Qt.DefaultContextMenu)
         self.device_menu = QMenu()
@@ -65,8 +67,8 @@ class BaseDeviceButton(QPushButton):
             if device.name not in menu_devices:
                 # Add to device menu
                 show_device = LucidMainWindow.in_dock(
-                                        partial(self.show_device, device),
-                                        title=device.name)
+                    partial(self.show_device, device),
+                    title=device.name)
                 self.device_menu.addAction(device.name, show_device)
 
 
@@ -83,7 +85,7 @@ class IndicatorCell(BaseDeviceButton):
         self.setStyleSheet('QPushButton:!hover {border: None}')
         self.setLayout(SnakeLayout(self.max_columns))
         self.layout().setSpacing(self.spacing)
-        self.layout().setContentsMargins(*4*[self.margin])
+        self.layout().setContentsMargins(*4 * [self.margin])
         self._selecting_widgets = list()
         self.devices = list()
 
@@ -127,7 +129,7 @@ class IndicatorCell(BaseDeviceButton):
     def sizeHint(self):
         size_per_icon = self.icon_size + self.spacing
         return QSize(self.max_columns * size_per_icon
-                     + self.spacing + 2*self.margin,
+                     + self.spacing + 2 * self.margin,
                      70)
 
     def _devices_shown(self, shown, selector=None):
@@ -145,6 +147,7 @@ class IndicatorCell(BaseDeviceButton):
 
 class IndicatorGroup(BaseDeviceButton):
     """QPushButton to select an entire row or column of devices"""
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.setText(str(self.title))
@@ -175,6 +178,7 @@ class IndicatorGroup(BaseDeviceButton):
 
 class IndicatorGrid(QWidget):
     """GridLayout of all Indicators"""
+
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.setLayout(QGridLayout())


### PR DESCRIPTION
Most of this work I did yesterday while learning more about the PyQtAds and about lucid as well..
So feel free to chime in with the comments, suggestions and what not...

A couple of changes that I did here and points for discussion:
- Why not make the LucidMainWindow a singleton? (I know that some people hate it)...
- Somehow the args were not being passed to the wrapper of `in_dock`, this way it is but it seems wrong...
- I need to remove the `self.dock_area` which is unused... 