### PR TITLE
ENH: highlight cell that matches text

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -22,7 +22,8 @@ requirements:
     - pyqtads
     - ophyd
     - qtpy
-    - typhon >=0.4
+    - typhos >=0.4
+    - fuzzywuzzy
 
 test:
   imports:

--- a/lucid/__init__.py
+++ b/lucid/__init__.py
@@ -1,4 +1,4 @@
-__all__ = ['LucidMainWindow']
+__all__ = ['LucidMainWindow', 'main_window', 'overview']
 
 from .main_window import LucidMainWindow
 from . import main_window

--- a/lucid/__init__.py
+++ b/lucid/__init__.py
@@ -3,6 +3,7 @@ __all__ = ['LucidMainWindow', 'main_window', 'overview']
 from .main_window import LucidMainWindow
 from . import main_window
 from . import overview
+from . import utils
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/lucid/__init__.py
+++ b/lucid/__init__.py
@@ -1,6 +1,8 @@
 __all__ = ['LucidMainWindow']
 
 from .main_window import LucidMainWindow
+from . import main_window
+from . import overview
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/lucid/launcher.py
+++ b/lucid/launcher.py
@@ -89,7 +89,7 @@ def launch(beamline, *, toolbar=None, row_group_key="location_group",
 
     if beamline != 'DEMO':
         # Fill with Data from Happi
-        cli = happi.Client.from_config()
+        cli = lucid.utils.get_happi_client()
         devices = cli.search(beamline=beamline)
 
         for dev in devices:

--- a/lucid/launcher.py
+++ b/lucid/launcher.py
@@ -82,7 +82,9 @@ def launch(beamline, *, toolbar=None, row_group_key="location_group",
     handler.setLevel(log_level)
 
     app = QApplication([])
-
+    app.setOrganizationName("SLAC National Accelerator Laboratory")
+    app.setOrganizationDomain("slac.stanford.edu")
+    app.setApplicationName("LUCID")
     window = LucidMainWindow()
     typhon.use_stylesheet(dark=False)
     grid = lucid.overview.IndicatorGridWithOverlay()

--- a/lucid/launcher.py
+++ b/lucid/launcher.py
@@ -1,5 +1,8 @@
 import pathlib
 
+import lucid
+
+from qtpy import QtWidgets
 from PyQtAds import QtAds
 
 MODULE_PATH = pathlib.Path(__file__).parent
@@ -68,7 +71,6 @@ def launch(beamline, *, toolbar=None, row_group_key="location_group",
     import happi
     import typhon
     from .main_window import LucidMainWindow
-    from .overview import IndicatorGrid
 
     logger = logging.getLogger('')
     handler = logging.StreamHandler()
@@ -83,7 +85,7 @@ def launch(beamline, *, toolbar=None, row_group_key="location_group",
 
     window = LucidMainWindow()
     typhon.use_stylesheet(dark=False)
-    grid = IndicatorGrid()
+    grid = lucid.overview.IndicatorGridWithOverlay()
 
     if beamline != 'DEMO':
         # Fill with Data from Happi
@@ -117,7 +119,7 @@ def launch(beamline, *, toolbar=None, row_group_key="location_group",
                 grid.add_devices(devices, stand=stand, system=system)
 
     dock_widget = QtAds.CDockWidget('Grid')
-    dock_widget.setWidget(grid)
+    dock_widget.setWidget(grid.frame)
 
     dock_widget.setToggleViewActionMode(QtAds.CDockWidget.ActionModeShow)
 
@@ -126,6 +128,7 @@ def launch(beamline, *, toolbar=None, row_group_key="location_group",
     dock_widget.setFeature(dock_widget.DockWidgetMovable, False)
 
     window.dock_manager.addDockWidget(QtAds.LeftDockWidgetArea, dock_widget)
+    window.setMinimumSize(400, 400)
     window.show()
 
     app.exec_()

--- a/lucid/launcher.py
+++ b/lucid/launcher.py
@@ -128,7 +128,6 @@ def launch(beamline, *, toolbar=None, row_group_key="location_group",
     dock_widget.setFeature(dock_widget.DockWidgetMovable, False)
 
     window.dock_manager.addDockWidget(QtAds.LeftDockWidgetArea, dock_widget)
-    window.setMinimumSize(600, 600)
     window.show()
 
     app.exec_()

--- a/lucid/launcher.py
+++ b/lucid/launcher.py
@@ -128,7 +128,7 @@ def launch(beamline, *, toolbar=None, row_group_key="location_group",
     dock_widget.setFeature(dock_widget.DockWidgetMovable, False)
 
     window.dock_manager.addDockWidget(QtAds.LeftDockWidgetArea, dock_widget)
-    window.setMinimumSize(400, 400)
+    window.setMinimumSize(600, 600)
     window.show()
 
     app.exec_()

--- a/lucid/launcher.py
+++ b/lucid/launcher.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 
 import lucid
@@ -66,11 +67,8 @@ def parse_arguments(*args, **kwargs):
 
 def launch(beamline, *, toolbar=None, row_group_key="location_group",
            col_group_key="functional_group", log_level="INFO"):
-    import logging
-    from qtpy.QtWidgets import QApplication
     import happi
     import typhon
-    from .main_window import LucidMainWindow
 
     logger = logging.getLogger('')
     handler = logging.StreamHandler()
@@ -81,11 +79,11 @@ def launch(beamline, *, toolbar=None, row_group_key="location_group",
     logger.setLevel(log_level)
     handler.setLevel(log_level)
 
-    app = QApplication([])
+    app = QtWidgets.QApplication([])
     app.setOrganizationName("SLAC National Accelerator Laboratory")
     app.setOrganizationDomain("slac.stanford.edu")
     app.setApplicationName("LUCID")
-    window = LucidMainWindow()
+    window = lucid.main_window.LucidMainWindow()
     typhon.use_stylesheet(dark=False)
     grid = lucid.overview.IndicatorGridWithOverlay()
 

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -381,11 +381,11 @@ def _thread_grid_search(callback, *, general_search, category_search,
                                            threshold=threshold)
                 if ratio > threshold:
                     callback(
-                        source='cell',
+                        source='grid',
                         rank=ratio,
                         name=cell.title,
                         item=cell,
-                        reason='cell ' + match,
+                        reason=match,
                         callback=cell.click,
                     )
 
@@ -498,6 +498,44 @@ def _stringify_dict(d, skip_keys, prefix=' -', delim='\n'):
                      if key not in skip_keys)
 
 
+_ICONS = {}
+
+
+def _generate_icon(key):
+    'Generate a simple icon based on the first letter of the `source` key'
+    size = 128
+    main = LucidMainWindow.get_instance()
+    dpr = main.devicePixelRatioF()
+
+    pixmap = QtGui.QPixmap(size * dpr, size * dpr)
+    pixmap.setDevicePixelRatio(dpr)
+    pixmap.fill(Qt.transparent)
+
+    painter = QtGui.QPainter()
+    painter.begin(pixmap)
+    painter.setRenderHint(painter.Antialiasing)
+
+    rect = QtCore.QRect(0, 0, size - 1, size - 1)
+
+    font = QtGui.QFontDatabase.systemFont(QtGui.QFontDatabase.TitleFont)
+    font.setPixelSize(size)
+    font.setBold(True)
+    painter.setFont(font)
+
+    painter.drawEllipse(rect)
+    painter.setPen(Qt.darkBlue)
+    painter.drawText(rect, Qt.AlignCenter, key[0].upper())
+    painter.end()
+    return QtGui.QIcon(pixmap)
+
+
+def get_search_icon_by_source(source):
+    'Search result source -> QIcon'
+    if source not in _ICONS:
+        _ICONS[source] = _generate_icon(source)
+    return _ICONS[source]
+
+
 class SearchModelItem(QtGui.QStandardItem):
     def __init__(self, *, name, rank, item, reason, **info):
         '''
@@ -539,6 +577,7 @@ class SearchModelItem(QtGui.QStandardItem):
         )
 
         self.rank = rank
+        self.setIcon(get_search_icon_by_source(info['source']))
         self.setData(self.rank, Qt.UserRole)
         self.setData(tooltip, Qt.ToolTipRole)
         self.setEditable(False)

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -13,7 +13,7 @@ from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import (QMainWindow, QToolBar, QStyle, QSizePolicy,
                             QWidget)
 
-from .utils import fuzzy_match
+from .utils import fuzzy_match, display_for_device, get_happi_client
 
 
 logger = logging.getLogger(__name__)
@@ -417,7 +417,7 @@ def _thread_happi_search(callback, *, general_search, category_search,
     global _HAPPI_CACHE
     if _HAPPI_CACHE is None:
         # TODO: re-read happi after a certain interval?
-        client = happi.Client.from_config()
+        client = get_happi_client()
         _HAPPI_CACHE = list(client.search(as_dict=True))
 
     for item in _HAPPI_CACHE:

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -9,8 +9,8 @@ import fuzzywuzzy.fuzz
 from PyQtAds import QtAds
 from qtpy import QtCore, QtWidgets
 from qtpy.QtCore import Qt, Signal
-from qtpy.QtWidgets import (QMainWindow, QToolBar, QStyle,
-                            QLineEdit, QSizePolicy, QWidget)
+from qtpy.QtWidgets import (QMainWindow, QToolBar, QStyle, QSizePolicy,
+                            QWidget)
 
 logger = logging.getLogger(__name__)
 
@@ -287,7 +287,7 @@ class LucidMainWindow(QMainWindow):
         return wrapper
 
 
-class SearchLineEdit(QLineEdit):
+class SearchLineEdit(QtWidgets.QLineEdit):
     cancel_request = Signal()
 
     def __init__(self, *, main_window, parent=None):
@@ -295,6 +295,7 @@ class SearchLineEdit(QLineEdit):
 
         self.main = main_window
         self.setPlaceholderText("Search...")
+        self.setClearButtonEnabled(True)
         self.textChanged.connect(self.highlight_matches)
 
         def clear_highlight():

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -717,7 +717,11 @@ class SearchDialog(QtWidgets.QDialog):
 
 
 class SearchMatchList(QtWidgets.QListView):
-    def doubleClicked(self, index : QtCore.QModelIndex):
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.doubleClicked.connect(self._run_callback)
+
+    def _run_callback(self, index : QtCore.QModelIndex):
         proxy_model = self.model()
         model = proxy_model.sourceModel()
         item = model.itemFromIndex(proxy_model.mapToSource(index))
@@ -738,7 +742,7 @@ class SearchMatchList(QtWidgets.QListView):
             except Exception:
                 ...
             else:
-                self.doubleClicked(index)
+                self._run_callback(index)
                 return
 
         super().keyPressEvent(event)

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -7,7 +7,7 @@ import lucid
 import fuzzywuzzy.fuzz
 
 from PyQtAds import QtAds
-from qtpy.QtCore import Qt
+from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import (QMainWindow, QToolBar, QStyle,
                             QLineEdit, QSizePolicy, QWidget)
 
@@ -167,6 +167,19 @@ class LucidMainWindow(QMainWindow):
         return wrapper
 
 
+class SearchLineEdit(QLineEdit):
+    cancel_request = Signal()
+
+    def __init__(self):
+        super().__init__()
+
+        self.setPlaceholderText("Search...")
+        # self.cancelRequest.connect(self.clear_highlight)
+
+    # def keyPressEvent(self, ev):
+
+
+
 class LucidToolBar(QToolBar):
     """LucidToolBar for LucidMainWindow"""
 
@@ -187,8 +200,7 @@ class LucidToolBar(QToolBar):
                              QSizePolicy.MinimumExpanding)
         self.addWidget(spacer)
         # Search
-        self.search_edit = QLineEdit()
-        self.search_edit.setPlaceholderText("Search...")
+        self.search_edit = SearchLineEdit()
         self.search_edit.textChanged.connect(self.highlight_matches)
         self.addWidget(self.search_edit)
 
@@ -211,8 +223,9 @@ class LucidToolBar(QToolBar):
             for group_name, group in grid.groups.items():
                 for cell in group.cells:
                     old_ratio = grid.overlay.cell_to_percentage.get(cell, 0.0)
-                    new_ratio = max(fuzzywuzzy.fuzz.ratio(device.name, text) / 100.0
-                                    for device in cell.devices)
+                    new_ratio = max(fuzzywuzzy.fuzz.ratio(name.lower(),
+                                                          text.lower()) / 100.0
+                                    for name in cell.matchable_names)
                     if old_ratio != new_ratio:
                         grid.overlay.cell_to_percentage[cell] = new_ratio
                         updated = True

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -477,7 +477,7 @@ def _thread_happi_search(callback, *, general_search, category_search,
                 item_results.append((ratio, f'{key}: {value}'))
 
         for text in general_search:
-            for key in ['name', 'prefix', 'stand']:
+            for key in utils.HAPPI_GENERAL_SEARCH_KEYS:
                 value = item.get(key)
                 if value is not None:
                     ratio = utils.fuzzy_match(text, str(value),

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -381,6 +381,9 @@ def _thread_grid_search(callback, *, general_search, category_search,
         updated = False
         min_ratio = 0.0
         for group_name, group in grid.groups.items():
+            if group.orientation == 'row':
+                # Only iterate over vertical-column groups
+                continue
             for cell in group.cells:
                 ratio, match = _cell_match(cell, general_search,
                                            threshold=threshold)
@@ -829,6 +832,9 @@ class SearchLineEdit(QtWidgets.QLineEdit):
             updated = False
             min_ratio = 0.0
             for group_name, group in grid.groups.items():
+                if group.orientation == 'row':
+                    # Only iterate over vertical-column groups
+                    continue
                 for cell in group.cells:
                     old_ratio = grid.overlay.cell_to_percentage.get(cell, 0.0)
                     new_ratio, matched = _cell_match(cell, general_search)

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -7,7 +7,7 @@ import lucid
 import fuzzywuzzy.fuzz
 
 from PyQtAds import QtAds
-from qtpy import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtWidgets
 from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import (QMainWindow, QToolBar, QStyle,
                             QLineEdit, QSizePolicy, QWidget)
@@ -150,7 +150,8 @@ class LucidMainWindow(QMainWindow):
 
     def _restore_settings(self):
         app = QtWidgets.QApplication.instance()
-        settings = QtCore.QSettings(app.organizationName(), app.applicationName())
+        settings = QtCore.QSettings(app.organizationName(),
+                                    app.applicationName())
         geometry = settings.value('geometry', QtCore.QByteArray())
         if not geometry.isEmpty():
             self.restoreGeometry(geometry)
@@ -162,7 +163,8 @@ class LucidMainWindow(QMainWindow):
 
     def _save_settings(self):
         app = QtWidgets.QApplication.instance()
-        settings = QtCore.QSettings(app.organizationName(), app.applicationName())
+        settings = QtCore.QSettings(app.organizationName(),
+                                    app.applicationName())
         settings.setValue('geometry', self.saveGeometry())
         for key, value in self.settings.items():
             settings.setValue(key, value)
@@ -368,10 +370,5 @@ class LucidToolBar(QToolBar):
                              QSizePolicy.MinimumExpanding)
         self.addWidget(spacer)
         # Search
-        self.search_edit = SearchLineEdit(main_window=self._main_window)
+        self.search_edit = SearchLineEdit(main_window=self.parent())
         self.addWidget(self.search_edit)
-
-    @property
-    def _main_window(self):
-        return self.parent()
-

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -121,7 +121,6 @@ class LucidMainWindow(QMainWindow):
         self.dock_manager = None
         super().__init__(parent=parent)
         self.setup_ui()
-        self._restore_settings()
         self.__initialized = True
 
     def __new__(cls, *args, **kwargs):
@@ -136,6 +135,16 @@ class LucidMainWindow(QMainWindow):
         return cls.__instance
 
     def setup_ui(self):
+        # Menu
+        self.menu = LucidMainWindowMenu(self)
+        self.setMenuBar(self.menu)
+        self.menu.exit.triggered.connect(self.close)
+
+        # Restore settings prior to setting up the toolbar/dock
+        # TODO: look into why restoring geometry post-dock_manager
+        # instantiation causes y-offset/shrinking height
+        self._restore_settings()
+
         # Toolbar
         self.toolbar = LucidToolBar(self)
         self.addToolBar(Qt.TopToolBarArea, self.toolbar)
@@ -145,11 +154,6 @@ class LucidMainWindow(QMainWindow):
         self.dock_manager = QtAds.CDockManager(self)
         self.dock_manager.setStyleSheet(
             open(MODULE_PATH / 'dock_style.css', 'rt').read())
-
-        # Menu
-        self.menu = LucidMainWindowMenu(self)
-        self.setMenuBar(self.menu)
-        self.menu.exit.triggered.connect(self.close)
 
     @property
     def settings(self):

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -775,6 +775,15 @@ class SearchLineEdit(QtWidgets.QLineEdit):
         self.main.escape_pressed.connect(clear_highlight)
         self.main.window_moved.connect(self._reposition_search_frame)
 
+    def focusOutEvent(self, event):
+        'Search box lost keyboard focus'
+        if self.search_frame and self.search_frame.isVisible():
+            if not any(widget.hasFocus() for widget in
+                       self.search_frame.findChildren(QtWidgets.QWidget)):
+                self.clear_highlight()
+
+        super().focusOutEvent(event)
+
     def _reposition_search_frame(self, *, width=None, height=None):
         'Reposition search frame to bottom-left corner of this line edit'
         if not self.search_frame:

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -165,7 +165,6 @@ class LucidMainWindow(QMainWindow):
         settings = QtCore.QSettings(app.organizationName(), app.applicationName())
         settings.setValue('geometry', self.saveGeometry())
         for key, value in self.settings.items():
-            print('saving', key, value)
             settings.setValue(key, value)
 
     def keyPressEvent(self, ev):

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -609,6 +609,7 @@ class SearchModel(QtGui.QStandardItemModel):
         def new_result(**kw):
             self.new_result.emit(kw)
 
+        self._callback_results = set()
         self.search_threads = [
             _SearchThread(func, new_result, parent=self,
                           kwargs=dict(category_search=category_search,
@@ -622,6 +623,11 @@ class SearchModel(QtGui.QStandardItemModel):
         ]
 
     def add_result(self, info):
+        key = (info['name'], info['source'], info['reason'])
+        if key in self._callback_results:
+            return
+        self._callback_results.add(key)
+
         self.appendRow(SearchModelItem(**info))
 
     def cancel(self):

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -474,7 +474,7 @@ def _thread_happi_search(callback, *, general_search, category_search,
             if value is not None:
                 ratio = utils.fuzzy_match(text, str(value),
                                           threshold=threshold)
-                item_results.append((ratio, f'{key}: {value}'))
+                item_results.append((ratio, key, value))
 
         for text in general_search:
             for key in utils.HAPPI_GENERAL_SEARCH_KEYS:
@@ -482,20 +482,20 @@ def _thread_happi_search(callback, *, general_search, category_search,
                 if value is not None:
                     ratio = utils.fuzzy_match(text, str(value),
                                               threshold=threshold)
-                    item_results.append((ratio, f'{key}: {value}'))
+                    item_results.append((ratio, key, value))
 
         if not item_results:
             continue
 
         item_results.sort(reverse=True)
-        ratio, match = item_results[0]
+        ratio, key, value = item_results[0]
         if ratio > threshold:
             callback(
                 source='happi',
                 rank=ratio,
                 name=item['name'],
                 item=item,
-                reason=match,
+                reason=f'{key}: {value}',
                 callback=lambda ct=item: _happi_dict_to_display(ct),
             )
 

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -2,6 +2,8 @@ import functools
 import logging
 import pathlib
 
+import lucid
+
 from PyQtAds import QtAds
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (QMainWindow, QToolBar, QStyle,
@@ -183,6 +185,28 @@ class LucidToolBar(QToolBar):
                              QSizePolicy.MinimumExpanding)
         self.addWidget(spacer)
         # Search
-        edit = QLineEdit()
-        edit.setPlaceholderText("Search ...")
-        self.addWidget(edit)
+        self.search_edit = QLineEdit()
+        self.search_edit.setPlaceholderText("Search...")
+        self.search_edit.textChanged.connect(self.highlight_matches)
+        self.addWidget(self.search_edit)
+
+    @property
+    def _main_window(self):
+        return self.parent()
+
+    def highlight_matches(self, text):
+        text = text.strip()
+
+        if not text:
+            self.clear_highlight()
+            return
+
+        main = self._main_window
+        for grid in main.findChildren(lucid.overview.IndicatorGrid):
+            for group_name, group in grid.groups.items():
+                for device, indicator in group.device_to_indicator.items():
+                    indicator.highlighted = text.lower() in device.name.lower()
+                    print(indicator, device.name, indicator.highlighted)
+
+    def clear_highlight(self):
+        ...

--- a/lucid/overview.py
+++ b/lucid/overview.py
@@ -281,7 +281,8 @@ class IndicatorOverlay(QWidget):
                     cell_rect = QtCore.QRectF(cx, cy, diameter, diameter)
                     percent = self.cell_to_percentage.get(cell, 0.0)
                     if percent > draw_threshold:
-                        percent = (percent - draw_threshold) / (1 - draw_threshold)
+                        percent = ((percent - draw_threshold) /
+                                   (1 - draw_threshold))
                         yield cell, cell_rect, radius, percent
 
         painter.begin(buffer)

--- a/lucid/overview.py
+++ b/lucid/overview.py
@@ -154,11 +154,12 @@ class IndicatorCell(BaseDeviceButton):
 class IndicatorGroup(BaseDeviceButton):
     """QPushButton to select an entire row or column of devices"""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, orientation, **kwargs):
         super().__init__(*args, **kwargs)
         self.setText(str(self.title))
         self.cells = []
         self.installEventFilter(self)
+        self.orientation = orientation
 
     def add_cell(self, cell):
         self.cells.append(cell)
@@ -231,7 +232,8 @@ QWidget[selected="true"] {background-color: rgba(20, 140, 210, 150);}
 
     def _add_group(self, group, as_row):
         # Add to layout
-        group = IndicatorGroup(title=group)
+        group = IndicatorGroup(title=group,
+                               orientation='row' if as_row else 'column')
         self._groups[group.title] = group
         # Find the correct position
         if as_row:

--- a/lucid/overview.py
+++ b/lucid/overview.py
@@ -46,8 +46,7 @@ class BaseDeviceButton(QPushButton):
     def show_all(self):
         """Create a widget for contained devices"""
         if not self._suite:
-            self._suite = suite_for_devices(self.devices)
-            self._suite.setParent(self)
+            self._suite = suite_for_devices(self.devices, parent=self)
         else:
             # Check that any devices that have been added since our last show
             # request have been added to the TyphonSuite

--- a/lucid/overview.py
+++ b/lucid/overview.py
@@ -291,7 +291,11 @@ class IndicatorOverlay(QWidget):
         painter.fillRect(buffer.rect(), QtGui.QColor(0, 0, 0, 127))
 
         pen_size = 40
-        max_percent = max(self.cell_to_percentage.values())
+        try:
+            max_percent = max(self.cell_to_percentage.values())
+        except ValueError:
+            max_percent = 0.0
+
         draw_threshold = max_percent * 0.8
 
         for cell, cell_rect, radius, percent in cell_to_radius():

--- a/lucid/overview.py
+++ b/lucid/overview.py
@@ -305,8 +305,6 @@ class IndicatorOverlay(QWidget):
             else:
                 color = (1, 1, 1, percent)
 
-            if percent > 0.5:
-                print(cell.title, percent)
             gradient.setColorAt(0.7, QtGui.QColor.fromRgbF(*color))
             gradient.setColorAt(1, QtGui.QColor.fromRgbF(0, 0, 0, 0))
 

--- a/lucid/utils.py
+++ b/lucid/utils.py
@@ -141,3 +141,11 @@ def get_happi_client():
     if _HAPPI_CLIENT is None:
         _HAPPI_CLIENT = happi.Client.from_config()
     return _HAPPI_CLIENT
+
+
+def find_ancestor_widget(widget, cls):
+    'Find an ancestor of `widget` given its class `cls`'
+    while widget is not None:
+        if isinstance(widget, cls):
+            return widget
+        widget = widget.parent()

--- a/lucid/utils.py
+++ b/lucid/utils.py
@@ -1,5 +1,6 @@
 import logging
 
+import happi
 import fuzzywuzzy.fuzz
 
 from pydm.widgets import PyDMDrawingCircle
@@ -89,9 +90,9 @@ def display_for_device(device, display_type=None):
     return display
 
 
-def suite_for_devices(devices):
+def suite_for_devices(devices, *, parent=None):
     """Create a TyphonSuite to display multiple devices"""
-    suite = TyphonSuite()
+    suite = TyphonSuite(parent=parent)
     for device in devices:
         suite.add_device(device)
     return suite
@@ -127,3 +128,16 @@ def fuzzy_match(a, b, *, case_insensitive=True, threshold=50):
                 if s1 in s2:
                     return threshold
     return ratio
+
+
+_HAPPI_CLIENT = None
+
+
+def get_happi_client():
+    '''
+    Create and cache a happi client from configuration
+    '''
+    global _HAPPI_CLIENT
+    if _HAPPI_CLIENT is None:
+        _HAPPI_CLIENT = happi.Client.from_config()
+    return _HAPPI_CLIENT

--- a/lucid/utils.py
+++ b/lucid/utils.py
@@ -10,6 +10,8 @@ from typhon import TyphonDeviceDisplay, TyphonSuite
 
 logger = logging.getLogger(__name__)
 
+HAPPI_GENERAL_SEARCH_KEYS = ('name', 'prefix', 'stand')
+
 
 class SnakeLayout(QGridLayout):
     """

--- a/lucid/utils.py
+++ b/lucid/utils.py
@@ -1,5 +1,7 @@
 import logging
 
+import fuzzywuzzy.fuzz
+
 from pydm.widgets import PyDMDrawingCircle
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QGridLayout
@@ -93,3 +95,35 @@ def suite_for_devices(devices):
     for device in devices:
         suite.add_device(device)
     return suite
+
+
+def fuzzy_match(a, b, *, case_insensitive=True, threshold=50):
+    'Fuzzy matching of strings `a` and `b`, with some LUCID-specific tweaks'
+    if case_insensitive:
+        a = a.lower()
+        b = b.lower()
+
+    ratio = fuzzywuzzy.fuzz.ratio(a, b)
+    if ratio >= threshold:
+        return ratio
+
+    # Special case a few scenarios, returning a value just at the threshold
+    # of interest:
+    # * 'VGC1' should match 'vgc_1' - ignore underscores and check if the
+    #   string is in
+    # * 'abc' should match 'xyz abc123' - despite the low fuzzing similarity
+    # * 'abc' should match 'xyz 123 abc' - despite the low fuzzing similarity,
+    #   and with a score better than the previous
+    # TODO: there are very likely better ways of doing this
+    for ignore_char in [None, '_']:
+        for s1, s2 in [(a, b), (b, a)]:
+            if ignore_char:
+                s1 = s1.replace(ignore_char, '')
+                s2 = s2.replace(ignore_char, '')
+
+            if len(s1) > len(s2) > 2:
+                if s1.endswith(s2) or s1.startswith(s2):
+                    return threshold + 1
+                if s1 in s2:
+                    return threshold
+    return ratio

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ ophyd
 qtpy
 qtpy
 git+https://github.com/pcdshub/typhon
+fuzzywuzzy


### PR DESCRIPTION
Reminiscent of OSX's settings search, this adds a fuzzy finder that looks through cell names + device names to determine how a highlighting overlay is drawn. For example:

<img width="987" alt="image" src="https://user-images.githubusercontent.com/5139267/71919320-404e6d80-3139-11ea-92e9-355a0d7e3e0d.png">

Drop-down examples:
<img width="591" alt="image" src="https://user-images.githubusercontent.com/5139267/72015046-e4a5e200-3215-11ea-8b60-880ada9e67f2.png">
<img width="591" alt="image" src="https://user-images.githubusercontent.com/5139267/72015137-0e5f0900-3216-11ea-97f7-949ac3958c11.png">

Working on:
- [x] Menu to configure functionality
- [x] Save settings
- [x] Overlay working
- [x] Drop-down list that shows items directly
- [x] Drop-down fuzzy happi search

TODO / bugfix
- [x] Duplicates (where are these coming from?)
- [ ] Cached results (old search results are shown despite new screens showing up)
- [x] Double-click in search results list
- [x] Click in grid should hide overlay + search
- [ ] Rate limit keypress searching (research performance bottlenecks?)
- [x] Repositioning main window should reposition floating search results
- [x] Search results window size should be >= width of search text box