### PR TITLE
ENH: Context Manager to  force ophyd.Device to lazy_wait_for_connection=False

### DIFF
--- a/lucid/launcher.py
+++ b/lucid/launcher.py
@@ -103,7 +103,7 @@ class HappiLoader(QtCore.QThread):
                         dev_obj = happi.loader.from_container(dev,
                                                               threaded=True)
                         dev_groups[f"{stand}|{system}"].append(dev_obj)
-                    except ValueError as ex:
+                    except ValueError:
                         logger.exception('Failed to load device %s', dev)
                         continue
 

--- a/lucid/launcher.py
+++ b/lucid/launcher.py
@@ -23,7 +23,7 @@ def get_happi_entry_value(entry, key, search_extraneous=True):
         value = extraneous.get(key, None)
 
     if not value:
-        raise ValueError('Invalid Key for Device.')
+        raise ValueError(f'Invalid Key ({key} for {entry}.')
     return value
 
 
@@ -93,15 +93,16 @@ class HappiLoader(QtCore.QThread):
             cli = lucid.utils.get_happi_client()
             devices = cli.search(beamline=self.beamline) or []
 
-            for dev in devices:
-                try:
-                    stand = get_happi_entry_value(dev, row_group_key)
-                    system = get_happi_entry_value(dev, col_group_key)
-                    dev_obj = happi.loader.from_container(dev, threaded=True)
-                    dev_groups[f"{stand}|{system}"].append(dev_obj)
-                except ValueError as ex:
-                    print(ex)
-                    continue
+            with lucid.utils.no_device_lazy_load():
+                for dev in devices:
+                    try:
+                        stand = get_happi_entry_value(dev, row_group_key)
+                        system = get_happi_entry_value(dev, col_group_key)
+                        dev_obj = happi.loader.from_container(dev, threaded=True)
+                        dev_groups[f"{stand}|{system}"].append(dev_obj)
+                    except ValueError as ex:
+                        print(ex)
+                        continue
 
         else:
             # Fill with random fake simulated devices

--- a/lucid/launcher.py
+++ b/lucid/launcher.py
@@ -14,6 +14,8 @@ import lucid
 
 MODULE_PATH = pathlib.Path(__file__).parent
 
+logger = logging.getLogger(__name__)
+
 
 def get_happi_entry_value(entry, key, search_extraneous=True):
     extraneous = entry.extraneous
@@ -138,13 +140,13 @@ def launch(beamline, *, toolbar=None, row_group_key="location_group",
     # Re-enable sigint (usually blocked by pyqt)
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 
-    logger = logging.getLogger('')
+    lucid_logger = logging.getLogger('')
     handler = logging.StreamHandler()
     formatter = logging.Formatter(
         '[%(asctime)s] [%(levelname)-8s] - %(message)s')
     handler.setFormatter(formatter)
-    logger.addHandler(handler)
-    logger.setLevel(log_level)
+    lucid_logger.addHandler(handler)
+    lucid_logger.setLevel(log_level)
     handler.setLevel(log_level)
 
     app = QtWidgets.QApplication([])

--- a/lucid/launcher.py
+++ b/lucid/launcher.py
@@ -102,7 +102,7 @@ class HappiLoader(QtCore.QThread):
                                                               threaded=True)
                         dev_groups[f"{stand}|{system}"].append(dev_obj)
                     except ValueError as ex:
-                        print(ex)
+                        logger.exception('Failed to load device %s', dev)
                         continue
 
         else:

--- a/lucid/launcher.py
+++ b/lucid/launcher.py
@@ -23,7 +23,7 @@ def get_happi_entry_value(entry, key, search_extraneous=True):
         value = extraneous.get(key, None)
 
     if not value:
-        raise ValueError(f'Invalid Key ({key} for {entry}.')
+        raise ValueError(f'Invalid Key ({key} not in {entry}.')
     return value
 
 

--- a/lucid/launcher.py
+++ b/lucid/launcher.py
@@ -98,7 +98,8 @@ class HappiLoader(QtCore.QThread):
                     try:
                         stand = get_happi_entry_value(dev, row_group_key)
                         system = get_happi_entry_value(dev, col_group_key)
-                        dev_obj = happi.loader.from_container(dev, threaded=True)
+                        dev_obj = happi.loader.from_container(dev,
+                                                              threaded=True)
                         dev_groups[f"{stand}|{system}"].append(dev_obj)
                     except ValueError as ex:
                         print(ex)

--- a/lucid/utils.py
+++ b/lucid/utils.py
@@ -1,14 +1,17 @@
 import logging
 import re
 import time
+import contextlib
 
-import happi
 import fuzzywuzzy.fuzz
 
-from pydm.widgets import PyDMDrawingCircle
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QGridLayout
+
+import happi
+from pydm.widgets import PyDMDrawingCircle
 from typhos import TyphosDeviceDisplay, TyphosSuite
+from ophyd import Device
 
 logger = logging.getLogger(__name__)
 
@@ -89,18 +92,20 @@ def indicator_for_device(device):
 
 def display_for_device(device, display_type=None):
     """Create a TyphosDeviceDisplay for a given device"""
-    logger.debug("Creating device display for %r", device)
-    display = TyphosDeviceDisplay.from_device(device)
-    if display_type:
-        display.display_type = display_type
+    with no_device_lazy_load():
+        logger.debug("Creating device display for %r", device)
+        display = TyphosDeviceDisplay.from_device(device)
+        if display_type:
+            display.display_type = display_type
     return display
 
 
 def suite_for_devices(devices, *, parent=None):
     """Create a TyphosSuite to display multiple devices"""
-    suite = TyphosSuite(parent=parent)
-    for device in devices:
-        suite.add_device(device)
+    with no_device_lazy_load():
+        suite = TyphosSuite(parent=parent)
+        for device in devices:
+            suite.add_device(device)
     return suite
 
 
@@ -203,3 +208,17 @@ def get_happi_device_cache():
         _HAPPI_CACHE = (time.monotonic(), list(client.search(as_dict=True)))
 
     return _HAPPI_CACHE[1]
+
+
+@contextlib.contextmanager
+def no_device_lazy_load():
+    '''
+    Context manager which disables the ophyd.device.Device
+    `lazy_wait_for_connection` behavior and later restore its value.
+    '''
+    old_val = Device.lazy_wait_for_connection
+    Device.lazy_wait_for_connection = False
+    try:
+        yield
+    finally:
+        Device.lazy_wait_for_connection = old_val

--- a/lucid/utils.py
+++ b/lucid/utils.py
@@ -217,8 +217,8 @@ def no_device_lazy_load():
     `lazy_wait_for_connection` behavior and later restore its value.
     '''
     old_val = Device.lazy_wait_for_connection
-    Device.lazy_wait_for_connection = False
     try:
+        Device.lazy_wait_for_connection = False
         yield
     finally:
         Device.lazy_wait_for_connection = old_val

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ import pytest
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QWidget
 
-from lucid.utils import SnakeLayout
+from lucid.utils import SnakeLayout, no_device_lazy_load
 
 
 @pytest.mark.parametrize('direction,shape',
@@ -18,3 +18,12 @@ def test_snake_layout_add(qtbot, direction, shape):
         qtbot.addWidget(widget)
 
     assert (layout.columnCount(), layout.rowCount()) == shape
+
+
+def test_no_device_lazy_load():
+    from ophyd import Device
+    old_val = Device.lazy_wait_for_connection
+    with no_device_lazy_load():
+        assert Device.lazy_wait_for_connection is False
+
+    assert Device.lazy_wait_for_connection == old_val

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,9 +21,24 @@ def test_snake_layout_add(qtbot, direction, shape):
 
 
 def test_no_device_lazy_load():
-    from ophyd import Device
-    old_val = Device.lazy_wait_for_connection
-    with no_device_lazy_load():
-        assert Device.lazy_wait_for_connection is False
+    from ophyd import Device, Component as Cpt
 
-    assert Device.lazy_wait_for_connection == old_val
+    class TestDevice(Device):
+        c = Cpt(Device, suffix='Test')
+
+    dev = TestDevice(name='foo')
+
+    old_val = Device.lazy_wait_for_connection
+    assert dev.lazy_wait_for_connection is old_val
+    assert dev.c.lazy_wait_for_connection is old_val
+
+    with no_device_lazy_load():
+        dev2 = TestDevice(name='foo')
+
+        assert Device.lazy_wait_for_connection is False
+        assert dev2.lazy_wait_for_connection is False
+        assert dev2.c.lazy_wait_for_connection is False
+
+    assert Device.lazy_wait_for_connection is old_val
+    assert dev.lazy_wait_for_connection is old_val
+    assert dev.c.lazy_wait_for_connection is old_val


### PR DESCRIPTION
Description
-----------
Without setting lazy_wait_for_connection=False a device that has components which are classified as lazy will result in a blocking call when we try to read the configuration_attrs and other information as well.
Since on the UI we need to have the asynchronous behavior of the connection, which is different at an interactive shell usage, it is in our best interest to patch the Device class to have lazy_wait_for_connection=False by default. That allows us to introspect the inner components and assemble the screen as well as subscribe to callback for proper generation of the UI when this device and its signals connect.

This PR supersedes https://github.com/pcdshub/typhos/pull/234