### PR TITLE
TMP: a temporary patch for disabling floating on Linux

### DIFF
--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -1,6 +1,7 @@
 import functools
 import logging
 import pathlib
+import sys
 
 import happi
 import typhos
@@ -300,6 +301,10 @@ class LucidMainWindow(QMainWindow):
             widget.setParent(dock)
             window.dock_manager.addDockWidget(
                 QtAds.RightDockWidgetArea, dock)
+
+            if sys.platform == 'linux':
+                # TODO: fix PyQtAds bug on Linux
+                dock.setFeature(dock.DockWidgetFloatable, False)
 
             # Ensure the main dock is actually visible
             widget.raise_()


### PR DESCRIPTION
PyQtAds (all versions, including the latest unreleased 3.2.1) has a bug on Linux causing a segfault when floating any widget.

As this severely impacts functionality on Linux (our target platform), we're working to get this resolved in the upstream Qt-Advanced-Docking-System sooner rather than later. This temporary patch will then be removed.