### PR TITLE
FIX: Ensure that grid cols and rows are in alphabetical order

### DIFF
--- a/lucid/launcher.py
+++ b/lucid/launcher.py
@@ -140,6 +140,9 @@ def launch(beamline, *, toolbar=None, row_group_key="location_group",
     # Re-enable sigint (usually blocked by pyqt)
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 
+    # Silence the logger from pyPDB.dbd.yacc
+    logging.getLogger("pyPDB.dbd.yacc").setLevel(logging.WARNING)
+
     lucid_logger = logging.getLogger('')
     handler = logging.StreamHandler()
     formatter = logging.Formatter(

--- a/lucid/overview.py
+++ b/lucid/overview.py
@@ -373,8 +373,7 @@ class IndicatorGridWithOverlay(IndicatorGrid):
         data = collections.OrderedDict()
         for r in sorted(rows):
             for c in sorted(cols):
-                entry = items.get(f"{r}|{c}", None)
-                data[f"{r}|{c}"] = entry if entry else []
+                data[f"{r}|{c}"] = items.get(f"{r}|{c}") or []
 
         for location, dev_list in data.items():
             stand, system = location.split("|")


### PR DESCRIPTION
## Description
With exception of the sections missing zero padding, all now is back on alphabetical order.
The issue was due to the fact that cols and rows without devices were not generating a group.
Now we make sure that the groups are created even if no items are available for a particular combination.

Also taking the opportunity to silence the SPAM logger from pyPDB that was generating parser messages like crazy.

## Screenshots
<img width="993" alt="Screen Shot 2020-02-25 at 9 58 55 PM" src="https://user-images.githubusercontent.com/8185425/75316464-4815be80-581a-11ea-8865-4521219ead0c.png">

Closes https://github.com/pcdshub/lucid/issues/35 and https://github.com/pcdshub/lucid/issues/34