### PR TITLE
FIX: Adjust lucid initial size.

### DIFF
--- a/lucid/launcher.py
+++ b/lucid/launcher.py
@@ -162,6 +162,7 @@ def launch(beamline, *, toolbar=None, row_group_key="location_group",
 
     # Silence the logger from pyPDB.dbd.yacc
     logging.getLogger("pyPDB.dbd.yacc").setLevel(logging.WARNING)
+    logging.getLogger("ophyd").setLevel(logging.WARNING)
 
     lucid_logger = logging.getLogger('')
     handler = logging.StreamHandler()
@@ -190,7 +191,7 @@ def launch(beamline, *, toolbar=None, row_group_key="location_group",
     # Use custom exception handler
     exception.ExceptionDispatcher().newException.connect(window.handle_error)
 
-    grid = lucid.overview.IndicatorGridWithOverlay()
+    grid = lucid.overview.IndicatorGridWithOverlay(toolbar_file=toolbar)
 
     splash.update_status(f"Loading {beamline} devices")
 
@@ -200,40 +201,27 @@ def launch(beamline, *, toolbar=None, row_group_key="location_group",
                          group_keys=(row_group_key, col_group_key),
                          callbacks=cbs
                          )
+
+    def grid_to_dock():
+        dock_widget = QtAds.CDockWidget('Grid')
+        dock_widget.setToggleViewActionMode(QtAds.CDockWidget.ActionModeShow)
+        dock_widget.setFeature(dock_widget.DockWidgetClosable, False)
+        dock_widget.setFeature(dock_widget.DockWidgetFloatable, False)
+        dock_widget.setFeature(dock_widget.DockWidgetMovable, False)
+        dock_widget.setMinimumSizeHintMode(
+            QtAds.CDockWidget.MinimumSizeHintFromContent
+        )
+        dock_widget.setWidget(grid.frame,
+                              QtAds.CDockWidget.eInsertMode.ForceNoScrollArea)
+
+        window.dock_manager.addDockWidget(QtAds.LeftDockWidgetArea,
+                                          dock_widget)
+
     loader.finished.connect(splash.accept)
+    loader.finished.connect(grid_to_dock)
     loader.finished.connect(window.show)
+
     loader.start()
-
-    dock_widget = QtAds.CDockWidget('Grid')
-    dock_widget.setSizePolicy(QtWidgets.QSizePolicy.Minimum,
-                              QtWidgets.QSizePolicy.Minimum)
-    dock_widget.setWidget(grid.frame,
-                          QtAds.CDockWidget.eInsertMode.ForceNoScrollArea)
-
-    dock_widget.setToggleViewActionMode(QtAds.CDockWidget.ActionModeShow)
-
-    dock_widget.setFeature(dock_widget.DockWidgetClosable, False)
-    dock_widget.setFeature(dock_widget.DockWidgetFloatable, False)
-    dock_widget.setFeature(dock_widget.DockWidgetMovable, False)
-
-    window.dock_manager.addDockWidget(QtAds.LeftDockWidgetArea, dock_widget)
-
-    quick_toolbar = lucid.overview.QuickAccessToolbar()
-    quick_toolbar.toolsFile = toolbar
-
-    bar_widget = QtAds.CDockWidget('Quick Launcher Toolbar')
-    bar_widget.setSizePolicy(QtWidgets.QSizePolicy.Minimum,
-                             QtWidgets.QSizePolicy.Minimum)
-
-    bar_widget.setWidget(quick_toolbar,
-                         QtAds.CDockWidget.eInsertMode.ForceNoScrollArea)
-    bar_widget.setToggleViewActionMode(QtAds.CDockWidget.ActionModeShow)
-    bar_widget.setFeature(dock_widget.DockWidgetClosable, False)
-    bar_widget.setFeature(dock_widget.DockWidgetFloatable, False)
-    bar_widget.setFeature(dock_widget.DockWidgetMovable, False)
-
-    dock_widget.dockContainer().addDockWidget(QtAds.BottomDockWidgetArea,
-                                              bar_widget)
 
     app.exec_()
 

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -305,6 +305,7 @@ class LucidMainWindow(QMainWindow):
             QtAds.CDockWidget.MinimumSizeHintFromContent
         )
         dock.setWidget(widget)
+        widget.setParent(dock)
         self.dock_manager.addDockWidget(area, dock)
 
         # Ensure the main dock is actually visible

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -290,11 +290,21 @@ class LucidMainWindow(QMainWindow):
             dock.toggleView(True)
             return dock
 
+        # The current minimumSizeHint from the widget is too small ~(68, 68)
+        # Here we suggest the minimumSizeHint as being the size
+        def min_size_hint(*args, **kwargs):
+            return widget.sizeHint()
+        widget.minimumSizeHint = min_size_hint
+        widget.setSizePolicy(
+            QtWidgets.QSizePolicy.Ignored,
+            QtWidgets.QSizePolicy.Ignored
+        )
+
         dock = QtAds.CDockWidget(title)
-        dock.setSizePolicy(QtWidgets.QSizePolicy.Minimum,
-                           QtWidgets.QSizePolicy.Minimum)
-        dock.setWidget(widget, QtAds.CDockWidget.eInsertMode.ForceNoScrollArea)
-        # widget.setParent(dock)
+        dock.setMinimumSizeHintMode(
+            QtAds.CDockWidget.MinimumSizeHintFromContent
+        )
+        dock.setWidget(widget)
         self.dock_manager.addDockWidget(area, dock)
 
         # Ensure the main dock is actually visible

--- a/lucid/overview.py
+++ b/lucid/overview.py
@@ -354,17 +354,21 @@ class IndicatorOverlay(QWidget):
 
 
 class IndicatorGridWithOverlay(IndicatorGrid):
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, toolbar_file=None):
         super().__init__(parent=None)
         self.frame = QtWidgets.QFrame(parent)
         self.frame.setLayout(QtWidgets.QVBoxLayout())
         self.frame.layout().addWidget(self)
+        vertical_spacer = QtWidgets.QSpacerItem(
+            10, 40, QtWidgets.QSizePolicy.Minimum,
+            QtWidgets.QSizePolicy.MinimumExpanding
+        )
+        self.frame.layout().addItem(vertical_spacer)
 
-        verticalSpacer = QtWidgets.QSpacerItem(10, 10,
-                                               QtWidgets.QSizePolicy.Minimum,
-                                               QtWidgets.QSizePolicy.Expanding)
-        self.frame.layout().addItem(verticalSpacer)
-
+        if toolbar_file is not None:
+            quick_toolbar = lucid.overview.QuickAccessToolbar(self.frame)
+            quick_toolbar.toolsFile = toolbar_file
+            self.frame.layout().addWidget(quick_toolbar)
         self.overlay = IndicatorOverlay(self.frame, self)
         self.overlay.setVisible(False)
         self.stackUnder(self.overlay)
@@ -393,6 +397,7 @@ class QuickAccessToolbar(QtWidgets.QWidget):
     """Tab Widget with tabs containing buttons defined via a yaml file"""
     def __init__(self, parent=None):
         super().__init__(parent=parent)
+
         self._tools = None
         self._default_config = {'cols': 4}
         self._setup_ui()


### PR DESCRIPTION
Closes #57 

With the fixes here the grid will no longer be covered by opening a screen of by the toolbar.
I will submit some more fixes to the toolbar in a separated commit to make sure that it does not take too much space of the screen if many items are added into it.

Initial display size with a toolbar:
![image](https://user-images.githubusercontent.com/8185425/84527959-a4023700-ac93-11ea-990d-fff53905a41d.png)
