### PR TITLE
FIX: Try to compact LUCID main screen

### DIFF
--- a/lucid/overview.py
+++ b/lucid/overview.py
@@ -111,10 +111,10 @@ class BaseDeviceButton(QPushButton):
 
 class IndicatorCell(BaseDeviceButton):
     """Single Cell of Indicator Lights in the Overview Grid"""
-    max_columns = 6
+    max_columns = 5
     icon_size = 12
-    spacing = 2
-    margin = 10
+    spacing = 1
+    margin = 5
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -153,7 +153,7 @@ class IndicatorCell(BaseDeviceButton):
         size_per_icon = self.icon_size + self.spacing
         return QSize(self.max_columns * size_per_icon
                      + self.spacing + 2 * self.margin,
-                     70)
+                     48)
 
     def _devices_shown(self, shown, selector=None):
         """Callback when corresponding ``TyphosSuite`` is accessed"""

--- a/lucid/overview.py
+++ b/lucid/overview.py
@@ -445,7 +445,11 @@ class QuickAccessToolbar(QtWidgets.QWidget):
                 button_widget = self._button_factory(button_text,
                                                      button_config)
                 page.layout().addWidget(button_widget)
-            self.tab.addTab(page, tab_name)
+
+            scroll_area = QtWidgets.QScrollArea()
+            scroll_area.setWidgetResizable(True)
+            scroll_area.setWidget(page)
+            self.tab.addTab(scroll_area, tab_name)
 
     def _button_factory(self, text, config):
         tp = config.pop('type')

--- a/lucid/overview.py
+++ b/lucid/overview.py
@@ -153,7 +153,7 @@ class IndicatorCell(BaseDeviceButton):
         size_per_icon = self.icon_size + self.spacing
         return QSize(self.max_columns * size_per_icon
                      + self.spacing + 2 * self.margin,
-                     48)
+                     36)
 
     def _devices_shown(self, shown, selector=None):
         """Callback when corresponding ``TyphosSuite`` is accessed"""
@@ -359,13 +359,14 @@ class IndicatorGridWithOverlay(IndicatorGrid):
         self.frame = QtWidgets.QFrame(parent)
         self.frame.setLayout(QtWidgets.QVBoxLayout())
         self.frame.layout().addWidget(self)
-        vertical_spacer = QtWidgets.QSpacerItem(
-            10, 40, QtWidgets.QSizePolicy.Minimum,
-            QtWidgets.QSizePolicy.MinimumExpanding
-        )
-        self.frame.layout().addItem(vertical_spacer)
 
         if toolbar_file is not None:
+            vertical_spacer = QtWidgets.QSpacerItem(
+                10, 20, QtWidgets.QSizePolicy.Minimum,
+                QtWidgets.QSizePolicy.MinimumExpanding
+            )
+            self.frame.layout().addItem(vertical_spacer)
+
             quick_toolbar = lucid.overview.QuickAccessToolbar(self.frame)
             quick_toolbar.toolsFile = toolbar_file
             self.frame.layout().addWidget(quick_toolbar)
@@ -402,9 +403,6 @@ class QuickAccessToolbar(QtWidgets.QWidget):
         self._default_config = {'cols': 4}
         self._setup_ui()
 
-    def sizeHint(self):
-        return QtCore.QSize(100, 100)
-
     @Property(str)
     def toolsFile(self):
         return self._tools_file
@@ -421,8 +419,8 @@ class QuickAccessToolbar(QtWidgets.QWidget):
         self._assemble_tabs()
 
     def _setup_ui(self):
-        self.setSizePolicy(QtWidgets.QSizePolicy.Minimum,
-                           QtWidgets.QSizePolicy.Minimum)
+        self.setSizePolicy(QtWidgets.QSizePolicy.Preferred,
+                           QtWidgets.QSizePolicy.Preferred)
 
         main_layout = QtWidgets.QVBoxLayout()
         self.setLayout(main_layout)
@@ -446,9 +444,13 @@ class QuickAccessToolbar(QtWidgets.QWidget):
                                                      button_config)
                 page.layout().addWidget(button_widget)
 
+            def min_scroll_size_hint(*args, **kwargs):
+                return QtCore.QSize(40, 40)
+
             scroll_area = QtWidgets.QScrollArea()
             scroll_area.setWidgetResizable(True)
             scroll_area.setWidget(page)
+            scroll_area.minimumSizeHint = min_scroll_size_hint
             self.tab.addTab(scroll_area, tab_name)
 
     def _button_factory(self, text, config):


### PR DESCRIPTION
While this PR does not completely fix the issue for remote workers reported at #57 it helps to visualize the whole grid and allow users to access the buttons at the Quick Launch toolbar.

I tested it with my computer setting the resolution to the worst possible and it fits now.

Here is the screen with the default resolution for my monitor:
<img width="1049" alt="Screen Shot 2020-08-25 at 4 47 37 PM" src="https://user-images.githubusercontent.com/8185425/91239374-3a22f680-e6f4-11ea-876b-72289aef75bc.png">

And here it is with the lower resolution possible (1152x720):
<img width="1152" alt="image" src="https://user-images.githubusercontent.com/8185425/91239459-69d1fe80-e6f4-11ea-9768-ec8c53b973dc.png">

