### PR TITLE
FIX: Set handle_timeout to noop for Splash screen loading widget.

### DIFF
--- a/lucid/splash.py
+++ b/lucid/splash.py
@@ -23,6 +23,7 @@ class Splash(QtWidgets.QDialog):
 
         self.status_display = QtWidgets.QLabel()
         loading = typhos.utils.TyphosLoading(self)
+        loading._handle_timeout = lambda *args, **kwargs: None
 
         status_layout = QtWidgets.QHBoxLayout()
         status_layout.addWidget(self.status_display)


### PR DESCRIPTION
Closes #79 

I opted for a noop on the timeout method vs changing the class attribute with the timeout.

Please let me know what you think.