### PR TITLE
ENH: use AlarmCircle, if available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ jobs:
   allow_failures:
     # ** pyqtads is not available on PyPI, so this cannot succeed:
     - name: "Python 3.8 - PIP"
+    - name: "Python 3.9"
 
 import:
   - pcdshub/pcds-ci-helpers:travis/shared_configs/setup-env-ui.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
 jobs:
   allow_failures:
     # ** pyqtads is not available on PyPI, so this cannot succeed:
-    - name: "Python 3.6 - PIP"
+    - name: "Python 3.8 - PIP"
 
 import:
   - pcdshub/pcds-ci-helpers:travis/shared_configs/setup-env-ui.yml

--- a/lucid/launcher.py
+++ b/lucid/launcher.py
@@ -236,3 +236,7 @@ def main():
     args = parse_arguments()
     kwargs = vars(args)
     launch(**kwargs)
+
+
+if __name__ == "__main__":
+    main()

--- a/lucid/utils.py
+++ b/lucid/utils.py
@@ -15,7 +15,7 @@ from typhos.utils import no_device_lazy_load
 try:
     from typhos.alarm import TyphosAlarmCircle
 except ImportError:
-    # TODO: likely unnecessary back-compat
+    # Compatibility with older versions of typhos
     TyphosAlarmCircle = None
 
 

--- a/lucid/utils.py
+++ b/lucid/utils.py
@@ -12,6 +12,13 @@ from pydm.widgets import PyDMDrawingCircle
 from typhos import TyphosDeviceDisplay, TyphosSuite
 from typhos.utils import no_device_lazy_load
 
+try:
+    from typhos.alarm import TyphosAlarmCircle
+except ImportError:
+    # TODO: likely unnecessary back-compat
+    TyphosAlarmCircle = None
+
+
 logger = logging.getLogger(__name__)
 
 HAPPI_GENERAL_SEARCH_KEYS = ('name', 'prefix', 'stand')
@@ -74,19 +81,28 @@ class SnakeLayout(QGridLayout):
                           grid_position[1])
 
 
-def indicator_for_device(device):
-    """Create a QWidget to indicate the alarm state of a QWidget"""
-    # This is a placeholder. There will be a system for determining the mapping
-    # of Device to icon put in place
-    circle = PyDMDrawingCircle()
-    circle.setStyleSheet('PyDMDrawingCircle '
-                         '{border: none; '
-                         ' background: transparent;'
-                         ' qproperty-penColor: black;'
-                         ' qproperty-penWidth: 2;'
-                         ' qproperty-penStyle: SolidLine;'
-                         ' qproperty-brush: rgba(82,101,244,255);} ')
-    return circle
+if TyphosAlarmCircle is not None:
+    def indicator_for_device(device):
+        """Create a QWidget to indicate the alarm state of a QWidget"""
+        circle = TyphosAlarmCircle()
+        circle.add_device(device)
+        return circle
+else:
+    def indicator_for_device(device):
+        """Create a QWidget to indicate the alarm state of a QWidget"""
+        # This is a placeholder if a new version of typhos with alarm support
+        # is unavailable.
+        circle = PyDMDrawingCircle()
+        circle.setStyleSheet(
+            "PyDMDrawingCircle "
+            "{border: none; "
+            " background: transparent;"
+            " qproperty-penColor: black;"
+            " qproperty-penWidth: 2;"
+            " qproperty-penStyle: SolidLine;"
+            " qproperty-brush: rgba(82,101,244,255);} "
+        )
+        return circle
 
 
 def display_for_device(device, display_type=None):


### PR DESCRIPTION
## Description

I couldn't help but wonder how the new alarm functionality looked in typhos with https://github.com/pcdshub/typhos/pull/441

The answer is that it looks great! See the following view of RIX from psbuild in the grid:

<img width="1272" alt="image" src="https://user-images.githubusercontent.com/5139267/123702412-f1f2ca00-d817-11eb-9998-e35629ae92be.png">

<img width="383" alt="image" src="https://user-images.githubusercontent.com/5139267/123702832-7a716a80-d818-11eb-9cfc-40694d584ee1.png">

which is an accurate reflection of the alarm state:
<img width="493" alt="image" src="https://user-images.githubusercontent.com/5139267/123702981-a7258200-d818-11eb-93ab-cb152d3fca50.png">

<img width="378" alt="image" src="https://user-images.githubusercontent.com/5139267/123702852-7f361e80-d818-11eb-9887-11d06d83f1d4.png">
is similarly correctly determined:
<img width="243" alt="image" src="https://user-images.githubusercontent.com/5139267/123703028-b60c3480-d818-11eb-9f15-ebd9fa8e6560.png">

And the tooltips are fantastic.

## Context

Closes #86 (and steals a bit of Zach's thunder)
Supersedes #89 

## Notes

Back-compat with the previous implementation may be unnecessary. If you feel strongly one way or another, I'd happily modify this PR.

If we decide to remove backward-compatibility of typhos, I'll adjust the version pin once the relevant PR is in and typhos is tagged. Otherwise, LUCID can be tagged/released independently.