### PR TITLE
FIX: searching for happi devices was broken (SearchResults refactor)

### DIFF
--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -2,16 +2,15 @@ import functools
 import logging
 import pathlib
 
-import happi
 import typhos
-from PyQtAds import QtAds
-from qtpy import QtCore, QtWidgets, QtGui
-from qtpy.QtCore import Qt, Signal
-from qtpy.QtWidgets import QMainWindow, QStyle, QSizePolicy
-
 from pydm import exception
+from PyQtAds import QtAds
+from qtpy import QtCore, QtGui, QtWidgets
+from qtpy.QtCore import Qt, Signal
+from qtpy.QtWidgets import QMainWindow, QSizePolicy, QStyle
 
 import lucid
+
 from . import utils
 
 logger = logging.getLogger(__name__)

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -489,15 +489,12 @@ def _thread_screens_search(callback, *, general_search, category_search,
             )
 
 
-def _happi_dict_to_display(d):
-    name = d['name']
+def _happi_searchresult_to_display(search_result):
+    name = search_result['name']
 
     @LucidMainWindow.in_dock(title=f'[happi] {name}')
     def wrapped():
-        client = utils.get_happi_client()
-        # dictionary -> device container -> device -> display
-        happi_device = client.find_device(**d)
-        device = happi.loader.from_container(happi_device)
+        device = search_result.get()
         return utils.display_for_device(device)
 
     wrapped()
@@ -535,7 +532,7 @@ def _thread_happi_search(callback, *, general_search, category_search,
                 name=item['name'],
                 item=item,
                 reason=f'{key}: {value}',
-                callback=lambda ct=item: _happi_dict_to_display(ct),
+                callback=lambda ct=item: _happi_searchresult_to_display(ct),
             )
 
 


### PR DESCRIPTION
Closes #92 

Apparently no one has been using the search feature for over a year... which is a bit sad!

(`SearchResults` was introduced in https://github.com/pcdshub/happi/releases/tag/v1.5.0)

Also an indicator of inadequate tests in lucid, but 🤷‍♂️ 