### PR TITLE
ENH: centralized logging with screenshots

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+    -   id: no-commit-to-branch
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-ast
+    -   id: check-case-conflict
+    -   id: check-json
+    -   id: check-merge-conflict
+    -   id: check-symlinks
+    -   id: check-xml
+    -   id: check-yaml
+        exclude: '^(conda-recipe/meta.yaml)$'
+    -   id: debug-statements
+
+-   repo: https://gitlab.com/pycqa/flake8.git
+    rev: 3.9.2
+    hooks:
+    -   id: flake8
+
+-   repo: https://github.com/timothycrosley/isort
+    rev: 5.9.2
+    hooks:
+    -   id: isort

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - python >=3.6
     - fuzzywuzzy
     - ophyd
+    - pcdsutils
     - pydm
     - pyqt >=5
     - pyqtads

--- a/lucid/launcher.py
+++ b/lucid/launcher.py
@@ -6,14 +6,17 @@ import pathlib
 import random
 import signal
 
-from PyQtAds import QtAds
-from qtpy import QtCore, QtWidgets
-
 import happi  # noqa
-import lucid
+import pcdsutils.log
 import typhos
 import typhos.utils
 from pydm import exception
+from PyQtAds import QtAds
+from qtpy import QtCore, QtWidgets
+
+import lucid
+
+from . import utils
 
 MODULE_PATH = pathlib.Path(__file__).parent
 
@@ -29,6 +32,7 @@ def get_happi_entry_value(entry, key):
 
 def get_parser():
     import argparse
+
     from . import __version__
 
     proj_desc = "LUCID - LCLS User Control and Interface Design"
@@ -191,6 +195,10 @@ def launch(beamline, *, toolbar=None, row_group_key="location_group",
     splash.update_status("Creating Main Window")
     window = lucid.main_window.LucidMainWindow(dark=dark)
     window.setWindowTitle(f"LUCID - {beamline}")
+
+    # Configure centralized PCDS logging:
+    if utils.centralized_logging_enabled():
+        pcdsutils.log.configure_pcds_logging()
 
     # Install exception hook handler with dialog popup
     exception.install(use_default_handler=False)

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -192,6 +192,8 @@ class LucidMainWindow(QMainWindow):
         exc_type, exc_value, exc_trace = data
         logger.exception("An uncaught exception happened: %s", exc_value,
                          exc_info=data)
+
+        utils.log_exception_to_central_server(data)
         exception.raise_to_operator(exc_value)
 
     @property

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -188,12 +188,12 @@ class LucidMainWindow(QMainWindow):
                                                     dock_widget)
 
     @QtCore.Slot(tuple)
-    def handle_error(self, data):
-        exc_type, exc_value, exc_trace = data
+    def handle_error(self, exc_info):
+        exc_type, exc_value, exc_trace = exc_info
         logger.exception("An uncaught exception happened: %s", exc_value,
-                         exc_info=data)
+                         exc_info=exc_info)
 
-        utils.log_exception_to_central_server(data)
+        utils.log_exception_to_central_server(exc_info)
         exception.raise_to_operator(exc_value)
 
     @property

--- a/lucid/utils.py
+++ b/lucid/utils.py
@@ -318,8 +318,12 @@ def log_exception_to_central_server(
 
     message = message or f'[{context}] {exc_value}'
     if save_screenshots:
-        screenshot_id = save_all_screenshots()
-        message = f'id={screenshot_id} {message}'
+        try:
+            screenshot_id = save_all_screenshots()
+        except Exception:
+            logger.exception("Failed to save screenshots")
+        else:
+            message = f'id={screenshot_id} {message}'
 
     kwargs = dict()
     if sys.version_info >= (3, 8):

--- a/lucid/utils.py
+++ b/lucid/utils.py
@@ -235,21 +235,38 @@ def get_happi_device_cache():
 def screenshot_top_level_widgets():
     """Yield screenshots of all top-level widgets."""
     app = QApplication.instance()
-    for idx, widget in enumerate(app.topLevelWidgets()):
-        screenshot = widget.screen().grabWindow(widget.winId())
+    for screen_idx, screen in enumerate(app.screens(), 1):
+        logger.debug("Screen %d: %s %s", screen_idx, screen, screen.geometry())
+
+    primary_screen = app.primaryScreen()
+    logger.debug("Primary screen: %s", primary_screen)
+
+    def by_title(widget):
+        return widget.windowTitle() or str(id(widget))
+
+    index = 0
+    for widget in sorted(app.topLevelWidgets(), key=by_title):
+        if not widget.isVisible():
+            continue
+        screen = (
+            widget.screen()
+            if hasattr(widget, "screen")
+            else primary_screen
+        )
+        screenshot = screen.grabWindow(widget.winId())
         name = widget.windowTitle().replace(" ", "_")
-        suffix = ".{name}" if name else ""
-        yield f"{idx}{suffix}", screenshot
+        suffix = f".{name}" if name else ""
+        index += 1
+        yield f"{index}{suffix}", screenshot
 
 
 def save_all_screenshots(format="png") -> str:
     """Save screenshots of all top-level widgets to SCREENSHOT_DIR."""
     screenshot_id = str(uuid.uuid4())[:8]
     for name, screenshot in screenshot_top_level_widgets():
-        screenshot.save(
-            str(SCREENSHOT_DIR / f"{screenshot_id}.{name}.{format}"),
-            format
-        )
+        fn = str(SCREENSHOT_DIR / f"{screenshot_id}.{name}.{format}")
+        screenshot.save(fn, format)
+        logger.info("Saved screenshot: %s", fn)
     return screenshot_id
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 fuzzywuzzy
 happi
 ophyd
+pcdsutils
 pydm
 pyqt5>=5
 pyqtads


### PR DESCRIPTION
Features
-----
* Adds `pre-commit` config
* Enables centralized logging (picks up `pcdsutils` dependency)
* Takes screenshots of visible windows when an exception happens, recording the screenshot ID along with the log message

Notes
------
* Screenshots not working over X forwarding, not sure if I'm doing something wrong or if that's to be expected.
* Ultimately I think a general version of this could go in typhos, but it's not as easy to generalize as (e.g.) the recent documentation widget config