### PR TITLE
BUG: only list active devices on launch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,7 @@ env:
 jobs:
   allow_failures:
     # ** pyqtads is not available on PyPI, so this cannot succeed:
-    - name: "Python 3.8 - PIP"
-    - name: "Python 3.9 - PIP"
+    - name: "Python - PIP"
 
 import:
   - pcdshub/pcds-ci-helpers:travis/shared_configs/setup-env-ui.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
   allow_failures:
     # ** pyqtads is not available on PyPI, so this cannot succeed:
     - name: "Python 3.8 - PIP"
-    - name: "Python 3.9"
+    - name: "Python 3.9 - PIP"
 
 import:
   - pcdshub/pcds-ci-helpers:travis/shared_configs/setup-env-ui.yml

--- a/lucid/launcher.py
+++ b/lucid/launcher.py
@@ -96,7 +96,9 @@ class HappiLoader(QtCore.QThread):
     def _load_from_happi(self, row_group_key, col_group_key):
         '''Fill with Data from Happi'''
         cli = lucid.utils.get_happi_client()
-        results = cli.search(beamline=self.beamline) or []
+        results = (cli.search(beamline=self.beamline,
+                              active=True)
+                   or [])
 
         dev_groups = collections.defaultdict(list)
 


### PR DESCRIPTION
## Description
Only list devices with active=True metadata tags.  

## Motivation and Context
closes #101 

Doesn't really solve a more general problem (specifying device filter settings generically), but it does solve this problem

## How Has This Been Tested?
Interactively

## Where Has This Been Documented?
Issue and this PR

## Pre-merge checklist
- [x] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate