### PR TITLE
MAINT: increase the default timeout to help TMO load properly

### DIFF
--- a/lucid/launcher.py
+++ b/lucid/launcher.py
@@ -10,6 +10,7 @@ import happi  # noqa
 import pcdsutils.log
 import typhos
 import typhos.utils
+from ophyd.signal import EpicsSignalBase
 from pydm import exception
 from PyQtAds import QtAds
 from qtpy import QtCore, QtWidgets
@@ -245,6 +246,12 @@ def launch(beamline, *, toolbar=None, row_group_key="location_group",
 def main():
     args = parse_arguments()
     kwargs = vars(args)
+    # TODO make configurable
+    timeout = 10
+    EpicsSignalBase.set_defaults(
+        timeout=timeout,
+        connection_timeout=timeout,
+    )
     launch(**kwargs)
 
 


### PR DESCRIPTION
TMO was complaining about their typhos screens launched from lucid not being quite right. The enum value selection on some of the state devices would often come up with no options at all.

It looked similar to issues we saw in lightpath so I decided to boost the EpicsSignal timeouts for the application, like we did in lightpath. This does fix the issue and you can make the issue worse (more devices effected) if you drop the timeout to be arbitrarily low.

This probably shouldn't be the final form of this PR- I think timeout should be configurable, right? I'm not sure if it's best as a cli arg as part of the toolbar yaml or somewhere else. This is a reasonable band-aid though.

REF https://jira.slac.stanford.edu/browse/LCLSECSD-1659