### PR TITLE
WIP: test the version of the CI that runs python 3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,4 +48,4 @@ import:
   #   - Documentation using doctr
   #   - Conda Package - uploaded to pcds-dev and pcds-tag
   #   - PyPI
-  - ZLLentz/pcds-ci-helpers:travis/shared_configs/standard-python-conda.yml@enh_py310
+  - ZLLentz/pcds-ci-helpers:travis/shared_configs/standard-python-conda-latest.yml@enh_py310

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,4 +48,4 @@ import:
   #   - Documentation using doctr
   #   - Conda Package - uploaded to pcds-dev and pcds-tag
   #   - PyPI
-  - ZLLentz/pcds-ci-helpers:travis/shared_configs/standard-python-conda-latest.yml@enh_py310
+  - ZLLentz/pcds-ci-helpers:travis/shared_configs/standard-python-conda.yml@enh_py310

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,4 +48,4 @@ import:
   #   - Documentation using doctr
   #   - Conda Package - uploaded to pcds-dev and pcds-tag
   #   - PyPI
-  - pcdshub/pcds-ci-helpers:travis/shared_configs/standard-python-conda.yml
+  - ZLLentz/pcds-ci-helpers:travis/shared_configs/standard-python-conda.yml@enh_py310


### PR DESCRIPTION
Do not merge
I want to see how https://github.com/pcdshub/pcds-ci-helpers/pull/87 runs

I've picked lucid because it failed the python 3.10 test suite with clear normal exception messages