### PR TITLE
MAINT: make sure we pass ints to addWidget for python 3.10

### DIFF
--- a/lucid/utils.py
+++ b/lucid/utils.py
@@ -80,7 +80,7 @@ class SnakeLayout(QGridLayout):
         # Number of widgets already existing
         position = self.count()
         # Desired position based on current count
-        grid_position = [position / self.size, position % self.size]
+        grid_position = [position // self.size, position % self.size]
         # Start vertically if desired
         if self.direction == Qt.Vertical:
             grid_position.reverse()


### PR DESCRIPTION
The python 3.10 test suite fails on addWidget receiving floats.
This is my code golf submission for resolving it.

The floor division is appropriate and maintains the same layout behavior on both 3.9 and 3.10.

Regardless of this PR, lucid can't quite be run on python 3.10 yet. See https://github.com/pcdshub/pcds-envs/issues/205#issuecomment-1318976830