### PR TITLE
MNT: rename QtAds submodule to ads

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -24,8 +24,8 @@ requirements:
   - ophyd
   - pcdsutils
   - pydm
-  - pyqt >=5
-  - pyqtads
+  - pyqt =5
+  - pyqtads >=4
   - pyyaml
   - qtpy
   - typhos

--- a/lucid/launcher.py
+++ b/lucid/launcher.py
@@ -12,7 +12,7 @@ import typhos
 import typhos.utils
 from ophyd.signal import EpicsSignalBase
 from pydm import exception
-from PyQtAds import QtAds
+from PyQtAds import ads
 from qtpy import QtCore, QtWidgets
 
 import lucid
@@ -233,18 +233,18 @@ def launch(beamline, *, toolbar=None, row_group_key="location_group",
                              callbacks=cbs)
 
     def grid_to_dock():
-        dock_widget = QtAds.CDockWidget('Grid')
-        dock_widget.setToggleViewActionMode(QtAds.CDockWidget.ActionModeShow)
+        dock_widget = ads.CDockWidget('Grid')
+        dock_widget.setToggleViewActionMode(ads.CDockWidget.ActionModeShow)
         dock_widget.setFeature(dock_widget.DockWidgetClosable, False)
         dock_widget.setFeature(dock_widget.DockWidgetFloatable, False)
         dock_widget.setFeature(dock_widget.DockWidgetMovable, False)
         dock_widget.setMinimumSizeHintMode(
-            QtAds.CDockWidget.MinimumSizeHintFromContent
+            ads.CDockWidget.MinimumSizeHintFromContent
         )
         dock_widget.setWidget(grid.frame,
-                              QtAds.CDockWidget.eInsertMode.ForceNoScrollArea)
+                              ads.CDockWidget.eInsertMode.ForceNoScrollArea)
 
-        window.dock_manager.addDockWidget(QtAds.LeftDockWidgetArea,
+        window.dock_manager.addDockWidget(ads.LeftDockWidgetArea,
                                           dock_widget)
 
     loader.finished.connect(splash.accept)

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -4,7 +4,7 @@ import pathlib
 
 import typhos
 from pydm import exception
-from PyQtAds import QtAds
+from PyQtAds import ads
 from qtpy import QtCore, QtGui, QtWidgets
 from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import QMainWindow, QSizePolicy, QStyle
@@ -161,7 +161,7 @@ class LucidMainWindow(QMainWindow):
 
         # Use the dockmanager for the main window - it will set itself as the
         # central widget
-        self.dock_manager = QtAds.CDockManager(self)
+        self.dock_manager = ads.CDockManager(self)
         if self.dark:
             self.dock_manager.setStyleSheet(
                 open(MODULE_PATH / (
@@ -178,12 +178,12 @@ class LucidMainWindow(QMainWindow):
                 continue
 
             if dock_widget.isFloating():
-                self.dock_manager.addDockWidget(QtAds.RightDockWidgetArea,
+                self.dock_manager.addDockWidget(ads.RightDockWidgetArea,
                                                 dock_widget)
             elif dock_widget.isInFloatingContainer():
                 container = dock_widget.dockContainer()
                 for dock_widget in container.dockWidgets():
-                    self.dock_manager.addDockWidget(QtAds.RightDockWidgetArea,
+                    self.dock_manager.addDockWidget(ads.RightDockWidgetArea,
                                                     dock_widget)
 
     @QtCore.Slot(tuple)
@@ -261,12 +261,12 @@ class LucidMainWindow(QMainWindow):
 
         Returns
         -------
-        dock_widget : QtAds.DockWidget or None
+        dock_widget : ads.DockWidget or None
         '''
         return self.dock_manager.findDockWidget(title)
 
     def add_dock(self, title, widget, *,
-                 area=QtAds.RightDockWidgetArea):
+                 area=ads.RightDockWidgetArea):
         '''
         Add dock widget by title
 
@@ -279,7 +279,7 @@ class LucidMainWindow(QMainWindow):
             The DockWidget title
         widget : QWidget
             The widget to put inside the dock
-        area : QtAds.DockWidgetArea, optional
+        area : ads.DockWidgetArea, optional
             The area to put the dock in
         '''
         dock = self.find_dock_widget_by_title(title)
@@ -299,9 +299,9 @@ class LucidMainWindow(QMainWindow):
             QtWidgets.QSizePolicy.Ignored
         )
 
-        dock = QtAds.CDockWidget(title)
+        dock = ads.CDockWidget(title)
         dock.setMinimumSizeHintMode(
-            QtAds.CDockWidget.MinimumSizeHintFromContent
+            ads.CDockWidget.MinimumSizeHintFromContent
         )
         dock.setWidget(widget)
         widget.setParent(dock)
@@ -375,7 +375,7 @@ class LucidMainWindow(QMainWindow):
 
             dock = LucidMainWindow().add_dock(
                 title=dock_title, widget=widget,
-                area=QtAds.RightDockWidgetArea)
+                area=ads.RightDockWidgetArea)
 
             if active_slot:
                 dock.viewToggled.connect(active_slot)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ ophyd
 pcdsutils
 pydm
 pyqt5>=5
-pyqtads>=4
+pyqtads
 pyyaml
 qtpy
 typhos

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ ophyd
 pcdsutils
 pydm
 pyqt5>=5
-pyqtads
+pyqtads>=4
 pyyaml
 qtpy
 typhos


### PR DESCRIPTION
I expect this to fail for pip, which still has pyqtads=3.8.1 as its most recent version (Assuming 4.0.0 changed the module naming, but release notes were less than helpful)