### PR TITLE
ENH: apply the new filter from pcdsutils

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   - python >=3.9
   - fuzzywuzzy
   - ophyd
-  - pcdsutils
+  - pcdsutils >=0.14.0
   - pydm
   - pyqt =5
   - pyqtads >=4

--- a/lucid/launcher.py
+++ b/lucid/launcher.py
@@ -195,6 +195,7 @@ def launch(beamline, *, toolbar=None, row_group_key="location_group",
     lucid_logger.addHandler(handler)
     lucid_logger.setLevel(log_level)
     handler.setLevel(log_level)
+    pcdsutils.log.PydmDemotionFilter.install(only_duplicates=False)
 
     app = QtWidgets.QApplication([])
     app.setOrganizationName("SLAC National Accelerator Laboratory")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fuzzywuzzy
 happi
 ophyd
-pcdsutils
+pcdsutils>=0.14.0
 pydm
 pyqt5>=5
 pyqtads


### PR DESCRIPTION
Ignore (demote) one specific pydm at-exit error log, and opt in to future extensions to that demoter.

In the pcds-5.8.0 environment, enough qt details have changed that we now get a bunch of spammy error messages at application close. I've yet to be able to figure out a fix for this, so I think a prudent approach is to filter the log messages from ERROR to DEBUG.

This is a companion to https://github.com/pcdshub/pcdsutils/pull/81

