### PR TITLE
Multi beamline

### DIFF
--- a/demo/db.json
+++ b/demo/db.json
@@ -47,6 +47,30 @@
 		"invalid": true,
 		"functional_group": "Vacuum",
 		"location_group": "S 2"
+	},
+	"TV5L0-VGC-1": {
+		"_id": "TV1L0-VGC-1",
+		"active": true,
+		"args": [],
+		"beamline": "DEMO_BEAMLINE",
+		"creation": "Tue Feb 27 10:41:25 2018",
+		"device_class": "ophyd.sim.SynAxis",
+		"kwargs": {
+			"name": "{{name}}"
+		},
+		"last_edit": "Thu Apr 12 14:40:08 2018",
+		"macros": null,
+		"name": "tv1l0_vgc_1",
+		"parent": null,
+		"prefix": "TV1L0-VGC-1",
+		"screen": null,
+		"stand": "ST1",
+		"system": "Device",
+		"type": "pcdsdevices.happi.containers.LCLSItem",
+		"z": 1035.5,
+		"invalid": true,
+		"functional_group": "Vacuum",
+		"location_group": "S 3"
 	}
 
 }

--- a/lucid/launcher.py
+++ b/lucid/launcher.py
@@ -13,7 +13,6 @@ import typhos.utils
 from ophyd.signal import EpicsSignalBase
 from pydm import exception
 from qtpy import QtCore, QtWidgets
-from typing import Optional, Union
 
 import lucid
 
@@ -107,7 +106,7 @@ class HappiLoader(QtCore.QThread):
         cli = lucid.utils.get_happi_client()
         results = []
         for line in self.beamline:
-            results += cli.search(beamline=line, active=True) 
+            results += cli.search(beamline=line, active=True)
 
         dev_groups = collections.defaultdict(list)
 

--- a/lucid/launcher.py
+++ b/lucid/launcher.py
@@ -13,6 +13,7 @@ import typhos.utils
 from ophyd.signal import EpicsSignalBase
 from pydm import exception
 from qtpy import QtCore, QtWidgets
+from typing import Optional, Union
 
 import lucid
 
@@ -45,7 +46,8 @@ def get_parser():
     parser.add_argument(
         'beamline',
         help='Specify the beamline name to compose the home screen.',
-        type=str
+        type=str,
+        nargs='+'
     )
     parser.add_argument(
         '--toolbar',
@@ -103,9 +105,9 @@ class HappiLoader(QtCore.QThread):
     def _load_from_happi(self, row_group_key, col_group_key):
         '''Fill with Data from Happi'''
         cli = lucid.utils.get_happi_client()
-        results = (cli.search(beamline=self.beamline,
-                              active=True)
-                   or [])
+        results = []
+        for line in self.beamline:
+            results += cli.search(beamline=line, active=True) 
 
         dev_groups = collections.defaultdict(list)
 


### PR DESCRIPTION
In launcher.py change the beamline argument to a list.

e.g. load beamline K3 for TXI: lucid K3
e.g. load beamline K3 and TXI: lucid K3 TXI

We should actually not use TXI as a beamline?

Tested by launching a screen using `lucid K3` and `lucid K3 TXI`