### PR TITLE
MNT: always put a scrollbar on typhos screens launched from the grid

### DIFF
--- a/lucid/utils.py
+++ b/lucid/utils.py
@@ -124,7 +124,7 @@ def display_for_device(device, display_type=None):
     """Create a TyphosDeviceDisplay for a given device"""
     with no_device_lazy_load():
         logger.debug("Creating device display for %r", device)
-        display = TyphosDeviceDisplay.from_device(device)
+        display = TyphosDeviceDisplay.from_device(device, scroll_option="scrollbar")
         if display_type:
             display.display_type = display_type
     return display


### PR DESCRIPTION
This avoids dramatic resizes when a subscreen is an "embedded" screen (no scrollbar) but is very big and should need a scrollbar (looking at you, at2l0).

See https://jira.slac.stanford.edu/browse/ECS-8680 task 1.2
Tested using `lucid LFE` and trying to open AT2l0