### PR TITLE
FIX/TST: relative paths, relocatable tests

### DIFF
--- a/lucid/launcher.py
+++ b/lucid/launcher.py
@@ -47,7 +47,6 @@ def get_parser():
         help="Path to the YAML file describing the entries for the Quick" + " Access Toolbar.",
         default=None,
         required=False,
-        type=argparse.FileType("r", encoding="UTF-8"),
     )
     parser.add_argument(
         "--row_group_key", help="The Happi field to use for row grouping.", default="location_group", required=False

--- a/lucid/main_window.py
+++ b/lucid/main_window.py
@@ -1,4 +1,3 @@
-import io
 import logging
 import pathlib
 
@@ -33,7 +32,7 @@ class LucidMainWindow(QMainWindow):
         Standard qt parent argument
     """
 
-    def __init__(self, beamline: str, toolbar: str | io.StringIO | None, parent: QWidget | None = None):
+    def __init__(self, beamline: str, toolbar: str | None, parent: QWidget | None = None):
         super().__init__(parent=parent)
         self.beamline = beamline
         self.toolbar = toolbar

--- a/lucid/overview.py
+++ b/lucid/overview.py
@@ -315,19 +315,18 @@ class QuickAccessToolbar(QtWidgets.QWidget):
     def __init__(self, parent=None):
         super().__init__(parent=parent)
 
+        self._tools_file = ""
         self._tools = None
         self._default_config = {"cols": 4}
         self.default_dock_button = None
         self._setup_ui()
 
-    def set_tools_file(self, file):
+    def set_tools_file(self, file: str):
         if not file:
             return
-        if isinstance(file, (str, bytes, os.PathLike)):
-            with open(file) as tf:
-                self._tools = yaml.full_load(tf)
-        else:
-            self._tools = yaml.full_load(file)
+        self._tools_file = file
+        with open(file) as tf:
+            self._tools = yaml.full_load(tf)
         self._assemble_tabs()
 
     def _setup_ui(self):
@@ -383,6 +382,9 @@ class QuickAccessToolbar(QtWidgets.QWidget):
                 self.default_dock_button = btn
 
         for prop, val in config.items():
+            if prop == "filename":
+                if not os.path.isabs(val):
+                    val = os.path.join(os.path.dirname(self._tools_file), val)
             try:
                 setattr(btn, prop, val)
             except Exception as ex:

--- a/lucid/tests/TST_toolbar.yaml
+++ b/lucid/tests/TST_toolbar.yaml
@@ -6,8 +6,8 @@ Tab1:
   buttons:
     DOCK1:
         type: dock
-        filename: lucid/tests/dock1.ui
+        filename: dock1.ui
     DOCK2:
         type: dock
-        filename: lucid/tests/dock2.ui
+        filename: dock2.ui
         default: true

--- a/lucid/tests/conftest.py
+++ b/lucid/tests/conftest.py
@@ -1,7 +1,11 @@
+from pathlib import Path
+
 import pytest
 from pytestqt.qtbot import QtBot
 
 from lucid.dock import LucidDock
+
+TESTS_DIR = Path(__file__).parent.resolve()
 
 
 @pytest.fixture(scope="function")

--- a/lucid/tests/test_dock.py
+++ b/lucid/tests/test_dock.py
@@ -9,6 +9,8 @@ from qtpy.QtWidgets import QWidget
 import lucid.dock
 from lucid.dock import LucidDock, LucidDockButton
 
+from .conftest import TESTS_DIR
+
 
 @pytest.fixture(scope="function")
 def dock_button(qtbot: QtBot) -> LucidDockButton:
@@ -238,7 +240,7 @@ def test_not_clean_minimized_widgets(lucid_dock: LucidDock, qtbot: QtBot):
 
 
 def test_build_widget(dock_button: LucidDockButton):
-    dock_button.setFilename("lucid/tests/dock1.ui")
+    dock_button.setFilename(str(TESTS_DIR / "dock1.ui"))
     widget1 = dock_button.build_widget()
     assert widget1.windowTitle() == "DOCK1"
     widget2 = dock_button.build_widget()
@@ -246,7 +248,7 @@ def test_build_widget(dock_button: LucidDockButton):
 
 
 def test_build_widget_ui_edited(dock_button: LucidDockButton, tmp_path: Path):
-    local_ui = Path(__file__).parent / "dock1.ui"
+    local_ui = TESTS_DIR / "dock1.ui"
     temp_ui = tmp_path / "dock1.ui"
 
     with open(local_ui, "r") as fd:

--- a/lucid/tests/test_main_window.py
+++ b/lucid/tests/test_main_window.py
@@ -1,14 +1,14 @@
-from pathlib import Path
-
 import pytest
 from pytestqt.qtbot import QtBot
 
 from lucid.main_window import LucidMainWindow
 
+from .conftest import TESTS_DIR
+
 
 @pytest.fixture(scope="function")
 def main_window(qtbot: QtBot) -> LucidMainWindow:
-    main_window = LucidMainWindow(beamline="pytest", toolbar=str(Path(__file__).parent / "TST_toolbar.yaml"))
+    main_window = LucidMainWindow(beamline="pytest", toolbar=str(TESTS_DIR / "TST_toolbar.yaml"))
     main_window.resize(main_window.width_threshold + 100, main_window.height())
     qtbot.addWidget(main_window)
     return main_window
@@ -34,4 +34,4 @@ def test_dock_visibility(main_window: LucidMainWindow, qtbot: QtBot):
 
 
 def test_default_dock_widget(main_window: LucidMainWindow):
-    assert main_window.dock.tab_widgets[0][0].currentWidget().windowTitle() == "DOCK2"
+    assert main_window.dock.tab_widgets[0][0].currentWidget().windowTitle() == "DOCK2"  # type: ignore


### PR DESCRIPTION
- Allow dock buttons to use relative filepaths (relative to parent of yaml file)
- Fix issues with paths specified from the repo root in test suite: allows the test suite to be run from different working directories
- Remove strange argparse handling of file opening so we pass through the filenames appropriately

These are issues that I found while trying to run these tests on lucid after installation in an environment with:

```
pytest --pyargs lucid
```

Which I'd like to use as a convenient way to verify the install.

After these changes, the above command works great in an environment install.

Interactively, this still works the same for existing screens.